### PR TITLE
NIO Stability & Performance changes

### DIFF
--- a/java/com/meyer/muscle/iogateway/JZLibMessageIOGateway.java
+++ b/java/com/meyer/muscle/iogateway/JZLibMessageIOGateway.java
@@ -148,7 +148,10 @@ public class JZLibMessageIOGateway extends MessageIOGateway
    
    public Message unflattenMessage(ByteBuffer in) throws IOException, UnflattenFormatException , NotEnoughDataException
    {
-      if (in.remaining() < 8) throw new NotEnoughDataException(8-in.remaining());
+      if (in.remaining() < 8) {
+	      in.position(in.limit());
+	      throw new NotEnoughDataException(8-in.remaining());
+      }
 
       int numBytes = in.getInt();
       if (numBytes > getMaximumIncomingMessageSize()) throw new UnflattenFormatException("Incoming message was too large! (" + numBytes + " bytes, " + getMaximumIncomingMessageSize() + " allowed!)");

--- a/java/com/meyer/muscle/iogateway/MessageIOGateway.java
+++ b/java/com/meyer/muscle/iogateway/MessageIOGateway.java
@@ -51,13 +51,16 @@ public class MessageIOGateway implements AbstractMessageIOGateway
     
    public Message unflattenMessage(ByteBuffer in) throws IOException, UnflattenFormatException, NotEnoughDataException
    {
-      if (in.remaining() < 8) throw new NotEnoughDataException(8-in.remaining());
+      if (in.remaining() < 8) {
+	      in.position(in.limit());
+	      throw new NotEnoughDataException(8-in.remaining());
+      }
 
       int numBytes = in.getInt();
       if (numBytes > getMaximumIncomingMessageSize()) throw new UnflattenFormatException("Incoming message was too large! (" + numBytes + " bytes, " + getMaximumIncomingMessageSize() + " allowed!)");
 
       int encoding = in.getInt();
-      if (encoding != MUSCLE_MESSAGE_DEFAULT_ENCODING) throw new IOException();
+      if (encoding != MUSCLE_MESSAGE_DEFAULT_ENCODING) throw new IOException("ByteBuffer: " + in + " numBytes: " + numBytes + " encoding: " + encoding);
       if (in.remaining() < numBytes) 
       {
           in.position(in.limit());


### PR DESCRIPTION
- Fixed a bug causing communication failures in the NIO message unflattening.
  - Prior to throwing a NotEnoughDataException the position of the buffer wasn't being updated in MessageIOGateway and JZLibMessageIOGateway.
  - Updated the handling code for NotEnoughDataExceptions to no longer rely on the position of the buffer (but rather look at the buffer limit, or the amount previously read into the buffer) -- which basically makes the above change unnecessary, but I'm paranoid.
- Performance Related
  - Switched to a direct byte buffer, which is allocated by the OS outside of the GC's managed space.
  - Scoped the receiving byte buffer to the receiver, which cut down on a lot of time spent allocating short-lived buffers.
  - Added a constructor for the MessageReceiver to allocate it's buffer to the same size as the sockets underlying buffer and made use of the call where possible.
