### PR TITLE
Fix GCC warnings.

### DIFF
--- a/test/Makefile-mt
+++ b/test/Makefile-mt
@@ -2,7 +2,7 @@ CFLAGS = -I.. -g
 CXXFLAGS = $(CFLAGS) -DMUSCLE_ENABLE_ZLIB_ENCODING -DMUSCLE_AVOID_NEWNOTHROW -DMUSCLE_SINGLE_THREAD_ONLY
 LFLAGS =  
 LIBS =
-EXECUTABLES = testreflectclient
+EXECUTABLES =
 REGEXOBJS = 
 ZLIBOBJS = adler32.o deflate.o trees.o zutil.o inflate.o crc32.o inftrees.o compress.o inffast.o
 
@@ -24,19 +24,10 @@ ifeq ($(OSTYPE),beos)
     endif   
   endif
 else
-  ifeq ($(OSTYPE),freebsd4.0)
-     CXXFLAGS += -I/usr/include/machine
-  else
-     ifeq ($(OSTYPE),darwin)
-        CXX = c++
-        CXXFLAGS += -I/usr/include/machine
-     else
-        ifeq ($(SYSTEM),AtheOS)
-           VPATH += ../atheossupport
-           EXECUTABLES += testreflectclient
-           LIBS = -latheos
-        endif
-     endif
+  ifeq ($(SYSTEM),AtheOS)
+    VPATH += ../atheossupport
+    EXECUTABLES += testreflectclient
+    LIBS = -latheos
   endif
 endif
 

--- a/test/testendian.cpp
+++ b/test/testendian.cpp
@@ -25,7 +25,8 @@ static double * bigArrayDouble;
 static void PrintBytes(const void * b, int num)
 {
    const uint8 * b8 = (const uint8 *) b;
-   for (int i=0; i<num; i++) printf("%02x ", b8[i]); printf("\n");
+   for (int i=0; i<num; i++) printf("%02x ", b8[i]);
+   printf("\n");
 }
 
 static void Fail(const char * name, const void * orig, const void * xChange, const void * backAgain, int numBytes, int index)

--- a/test/testmini.cpp
+++ b/test/testmini.cpp
@@ -262,7 +262,8 @@ int main(int, char **)
          if (mmbuf)
          {
             MMFlattenMessage(mmsg, mmbuf);
-            for (uint32 i=0; i<mmBufSize; i++) printf("%02x ", mmbuf[i]); printf("\n");
+            for (uint32 i=0; i<mmBufSize; i++) printf("%02x ", mmbuf[i]);
+            printf("\n");
 
             mmsg2 = MMAllocMessage(0);
             if (mmsg2)
@@ -308,7 +309,8 @@ int main(int, char **)
          if (buf)
          {
             m.Flatten(buf);
-            for (uint32 i=0; i<bufSize; i++) printf("%02x ", buf[i]); printf("\n");
+            for (uint32 i=0; i<bufSize; i++) printf("%02x ", buf[i]);
+            printf("\n");
          }
       }
  

--- a/test/testnetutil.cpp
+++ b/test/testnetutil.cpp
@@ -14,6 +14,7 @@ public:
 
    virtual status_t GetIPAddressForHostName(const char * name, bool expandLocalhost, bool preferIPv6, IPAddress & retIPAddress)
    {
+      (void)retIPAddress;
       printf("TestHostNameResolver (priority %i):  name=[%s] expandLocalhost=%i preferIPv6=%i\n", _pri, name, expandLocalhost, preferIPv6);
       return B_ERROR;
    }

--- a/test/testqueue.cpp
+++ b/test/testqueue.cpp
@@ -195,7 +195,8 @@ int main(void)
       if (q.AddTailMulti(vars, ARRAYITEMS(vars)) == B_NO_ERROR)
       {
          q.RemoveDuplicateItems(); 
-         for (uint32 i=0; i<q.GetNumItems(); i++) printf("%u ", q[i]); printf("\n");
+         for (uint32 i=0; i<q.GetNumItems(); i++) printf("%u ", q[i]);
+         printf("\n");
       }
    }
 

--- a/test/testserial.cpp
+++ b/test/testserial.cpp
@@ -23,7 +23,8 @@ int main(int /*argc*/, char ** /*argv*/)
          for (int32 i=0; i<ret; i++) printf("%02x ", buf[i]);
          printf("]\n");
          printf("aka [");
-         for (int32 j=0; j<ret; j++) printf("%c", buf[j]); printf("\n");
+         for (int32 j=0; j<ret; j++) printf("%c", buf[j]);
+         printf("\n");
 
          if (++c == 20)
          {


### PR DESCRIPTION
* GCC issues warning if multiple statements are used on same line as "for" statement without {...}.
* GCC issues warning if function parameter is not used.