### PR TITLE
Add SocketDescriptor type

### DIFF
--- a/dataio/ChildProcessDataIO.cpp
+++ b/dataio/ChildProcessDataIO.cpp
@@ -303,7 +303,7 @@ status_t ChildProcessDataIO :: LaunchChildProcessAux(int argc, const void * args
            if (pid > 0) _handle = masterSock;
       else if (pid == 0)
       {
-         int fd = slaveSock()->GetFileDescriptor();
+         int fd = slaveSock()->GetSocketDescriptor();
          if ((launchFlags.IsBitSet(CHILD_PROCESS_LAUNCH_FLAG_EXCLUDE_STDIN)  == false)&&(dup2(fd, STDIN_FILENO)  < 0)) ExitWithoutCleanup(20);
          if ((launchFlags.IsBitSet(CHILD_PROCESS_LAUNCH_FLAG_EXCLUDE_STDOUT) == false)&&(dup2(fd, STDOUT_FILENO) < 0)) ExitWithoutCleanup(20);
          if ((launchFlags.IsBitSet(CHILD_PROCESS_LAUNCH_FLAG_EXCLUDE_STDERR) == false)&&(dup2(fd, STDERR_FILENO) < 0)) ExitWithoutCleanup(20);
@@ -425,7 +425,7 @@ bool ChildProcessDataIO :: IsChildProcessAvailable() const
 #ifdef USE_WINDOWS_CHILDPROCESSDATAIO_IMPLEMENTATION
    return (_readFromStdout != INVALID_HANDLE_VALUE);
 #else
-   return (_handle.GetFileDescriptor() >= 0);
+   return (_handle.GetSocketDescriptor() >= 0);
 #endif
 } 
 
@@ -624,7 +624,7 @@ int32 ChildProcessDataIO :: Read(void *buf, uint32 len)
          return ret;
       }
 #else
-      const long r = read_ignore_eintr(_handle.GetFileDescriptor(), buf, len);
+      const long r = read_ignore_eintr(_handle.GetSocketDescriptor(), buf, len);
       return _blocking ? (int32)r : ConvertReturnValueToMuscleSemantics(r, len, _blocking);
 #endif
    }
@@ -650,7 +650,7 @@ int32 ChildProcessDataIO :: Write(const void *buf, uint32 len)
          return ret;
       }
 #else
-      return ConvertReturnValueToMuscleSemantics(write_ignore_eintr(_handle.GetFileDescriptor(), buf, len), len, _blocking);
+      return ConvertReturnValueToMuscleSemantics(write_ignore_eintr(_handle.GetSocketDescriptor(), buf, len), len, _blocking);
 #endif
    }
    return -1;

--- a/dataio/FileDataIO.cpp
+++ b/dataio/FileDataIO.cpp
@@ -90,7 +90,7 @@ void FileDataIO :: SetSocketsFromFile(FILE * optFile)
    const int fd = optFile ? fileno(optFile) : -1;
    if (fd >= 0)
    {
-      _selectSocket.SetFileDescriptor(fd, false);  // false because the fclose() will call close(fd), so we should not
+      _selectSocket.SetSocketDescriptor(fd, false);  // false because the fclose() will call close(fd), so we should not
       _selectSocketRef.SetRef(&_selectSocket, false);
    } 
 #else

--- a/dataio/FileDescriptorDataIO.cpp
+++ b/dataio/FileDescriptorDataIO.cpp
@@ -34,14 +34,14 @@ FileDescriptorDataIO ::
 {
    if (_dofSyncOnClose)
    {
-      const int fd = _fd.GetFileDescriptor();
+      const int fd = _fd.GetSocketDescriptor();
       if (fd >= 0) (void) fsync(fd);
    }
 }
 
 int32 FileDescriptorDataIO :: Read(void * buffer, uint32 size)  
 {
-   const int fd = _fd.GetFileDescriptor();
+   const int fd = _fd.GetSocketDescriptor();
    if (fd >= 0)
    {
       const long r = read_ignore_eintr(fd, buffer, size);
@@ -52,7 +52,7 @@ int32 FileDescriptorDataIO :: Read(void * buffer, uint32 size)
 
 int32 FileDescriptorDataIO :: Write(const void * buffer, uint32 size)
 {
-   const int fd = _fd.GetFileDescriptor();
+   const int fd = _fd.GetSocketDescriptor();
    if (fd >= 0)
    {
       const long w = write_ignore_eintr(fd, buffer, size);
@@ -68,7 +68,7 @@ void FileDescriptorDataIO :: FlushOutput()
 
 status_t FileDescriptorDataIO :: SetBlockingIOEnabled(bool blocking)
 {
-   const int fd = _fd.GetFileDescriptor();
+   const int fd = _fd.GetSocketDescriptor();
    if (fd >= 0)
    {
       if (fcntl(fd, F_SETFL, blocking ? 0 : O_NONBLOCK) == 0)
@@ -88,7 +88,7 @@ void FileDescriptorDataIO :: Shutdown()
 
 status_t FileDescriptorDataIO :: Seek(int64 offset, int whence)
 {
-   const int fd = _fd.GetFileDescriptor();
+   const int fd = _fd.GetSocketDescriptor();
    if (fd < 0) return B_BAD_OBJECT;
 
    switch(whence)
@@ -109,7 +109,7 @@ status_t FileDescriptorDataIO :: Seek(int64 offset, int whence)
 
 int64 FileDescriptorDataIO :: GetPosition() const
 {
-   const int fd = _fd.GetFileDescriptor();
+   const int fd = _fd.GetSocketDescriptor();
    if (fd >= 0)
    {
 #ifdef MUSCLE_USE_LLSEEK

--- a/dataio/RS232DataIO.cpp
+++ b/dataio/RS232DataIO.cpp
@@ -55,7 +55,7 @@ RS232DataIO :: RS232DataIO(const char * port, uint32 baudRate, bool blocking)
          dcb.fBinary           = 1;
          dcb.fOutX             = 0;
          dcb.fInX              = 0;
-         dcb.fErrorChar        = 0xfe;
+         dcb.fErrorChar        = 1;
          dcb.fTXContinueOnXoff = 0;
          dcb.fOutxCtsFlow      = 0;
          dcb.fOutxDsrFlow      = 0;
@@ -64,6 +64,7 @@ RS232DataIO :: RS232DataIO(const char * port, uint32 baudRate, bool blocking)
          dcb.fNull             = 0;
          dcb.fRtsControl       = RTS_CONTROL_DISABLE;
          dcb.fAbortOnError     = 0;
+         dcb.ErrorChar         = -2;
          if (SetCommState(_handle, &dcb))
          {
             COMMTIMEOUTS tmout;
@@ -103,7 +104,7 @@ RS232DataIO :: RS232DataIO(const char * port, uint32 baudRate, bool blocking)
    {
       okay = true;
 
-      const int fd = _handle.GetFileDescriptor();
+      const int fd = _handle.GetSocketDescriptor();
 
       struct termios t;
       tcgetattr(fd, &t);
@@ -166,7 +167,7 @@ bool RS232DataIO :: IsPortAvailable() const
 #ifdef USE_WINDOWS_IMPLEMENTATION
    return (_handle != INVALID_HANDLE_VALUE);
 #else
-   return (_handle.GetFileDescriptor() >= 0);
+   return (_handle.GetSocketDescriptor() >= 0);
 #endif
 } 
 
@@ -246,7 +247,7 @@ void RS232DataIO :: FlushOutput()
 #ifdef USE_WINDOWS_IMPLEMENTATION
       // not implemented yet!
 #else 
-      const int fd = _handle.GetFileDescriptor();
+      const int fd = _handle.GetSocketDescriptor();
       if (fd >= 0) tcdrain(fd);
 #endif
    }

--- a/html/muscle-by-example/examples/dataio/example_2_tcp_server.cpp
+++ b/html/muscle-by-example/examples/dataio/example_2_tcp_server.cpp
@@ -49,18 +49,18 @@ int main(int argc, char ** argv)
    while(true)
    {
       // Tell the SocketMultiplexer what sockets to listen to
-      sm.RegisterSocketForReadReady(stdinIO.GetReadSelectSocket().GetFileDescriptor());
-      sm.RegisterSocketForReadReady(acceptSock.GetFileDescriptor());
+      sm.RegisterSocketForReadReady(stdinIO.GetReadSelectSocket().GetSocketDescriptor());
+      sm.RegisterSocketForReadReady(acceptSock.GetSocketDescriptor());
       for (HashtableIterator<DataIORef, Void> iter(tcpClients); iter.HasData(); iter++)
       {
-         sm.RegisterSocketForReadReady(iter.GetKey()()->GetReadSelectSocket().GetFileDescriptor());
+         sm.RegisterSocketForReadReady(iter.GetKey()()->GetReadSelectSocket().GetSocketDescriptor());
       }
 
       // Wait here until something happens
       (void) sm.WaitForEvents();
 
       // Time to accept an incoming TCP connection?
-      if (sm.IsSocketReadyForRead(acceptSock.GetFileDescriptor()))
+      if (sm.IsSocketReadyForRead(acceptSock.GetSocketDescriptor()))
       {
          IPAddress clientIP;
          ConstSocketRef tcpSock = Accept(acceptSock, &clientIP);
@@ -74,7 +74,7 @@ int main(int argc, char ** argv)
       }
 
       // Time to read from stdin?
-      if (sm.IsSocketReadyForRead(stdinIO.GetReadSelectSocket().GetFileDescriptor()))
+      if (sm.IsSocketReadyForRead(stdinIO.GetReadSelectSocket().GetSocketDescriptor()))
       {
          char inputBuf[1024];
          const int numBytesRead = stdinIO.Read(inputBuf, sizeof(inputBuf));
@@ -97,7 +97,7 @@ int main(int argc, char ** argv)
       for (HashtableIterator<DataIORef, Void> iter(tcpClients); iter.HasData(); iter++)
       {
          DataIO * clientIO = iter.GetKey()();
-         if (sm.IsSocketReadyForRead(clientIO->GetReadSelectSocket().GetFileDescriptor()))
+         if (sm.IsSocketReadyForRead(clientIO->GetReadSelectSocket().GetSocketDescriptor()))
          {
             char inputBuf[1024];
             const int numBytesRead = clientIO->Read(inputBuf, sizeof(inputBuf)-1);

--- a/html/muscle-by-example/examples/dataio/example_6_child_process.cpp
+++ b/html/muscle-by-example/examples/dataio/example_6_child_process.cpp
@@ -48,14 +48,14 @@ int main(int argc, char ** argv)
    while(true)
    {
       // Tell the SocketMultiplexer what sockets to listen to
-      sm.RegisterSocketForReadReady(stdinIO.GetReadSelectSocket().GetFileDescriptor());
-      sm.RegisterSocketForReadReady(cpIO.GetReadSelectSocket().GetFileDescriptor());
+      sm.RegisterSocketForReadReady(stdinIO.GetReadSelectSocket().GetSocketDescriptor());
+      sm.RegisterSocketForReadReady(cpIO.GetReadSelectSocket().GetSocketDescriptor());
 
       // Wait here until something happens
       (void) sm.WaitForEvents();
 
       // Time to read from stdin?
-      if (sm.IsSocketReadyForRead(stdinIO.GetReadSelectSocket().GetFileDescriptor()))
+      if (sm.IsSocketReadyForRead(stdinIO.GetReadSelectSocket().GetSocketDescriptor()))
       {
          char inputBuf[1024];
          const int numBytesRead = stdinIO.Read(inputBuf, sizeof(inputBuf));
@@ -72,7 +72,7 @@ int main(int argc, char ** argv)
       }
 
       // Time to read from the child process's stdout?
-      if (sm.IsSocketReadyForRead(cpIO.GetReadSelectSocket().GetFileDescriptor()))
+      if (sm.IsSocketReadyForRead(cpIO.GetReadSelectSocket().GetSocketDescriptor()))
       {
          char inputBuf[1024];
          const int numBytesRead = cpIO.Read(inputBuf, sizeof(inputBuf)-1);

--- a/html/muscle-by-example/examples/hashtable/example_6_key_types.cpp
+++ b/html/muscle-by-example/examples/hashtable/example_6_key_types.cpp
@@ -136,7 +136,7 @@ int main(int argc, char ** argv)
    for (HashtableIterator<ConstSocketRef, Void> iter(sockTable); iter.HasData(); iter++)
    {
       const Socket * s = iter.GetKey()();
-      printf("   socket descriptor #%i\n", s ? s->GetFileDescriptor() : -1);
+      printf("   socket descriptor #" SOCKET_FORMAT_SPEC "\n", s ? s->GetSocketDescriptor() : INVALID_SOCKET);
    }
 
    printf("\n");

--- a/html/muscle-by-example/examples/iogateway/example_2_message_to_tcp.cpp
+++ b/html/muscle-by-example/examples/iogateway/example_2_message_to_tcp.cpp
@@ -109,21 +109,21 @@ int main(int argc, char ** argv)
    while(keepGoing)
    {
       // Tell the SocketMultiplexer what file descriptors to watch
-      sm.RegisterSocketForReadReady(stdinIO.GetReadSelectSocket().GetFileDescriptor());
-      sm.RegisterSocketForReadReady(gateway.GetDataIO()()->GetReadSelectSocket().GetFileDescriptor());
+      sm.RegisterSocketForReadReady(stdinIO.GetReadSelectSocket().GetSocketDescriptor());
+      sm.RegisterSocketForReadReady(gateway.GetDataIO()()->GetReadSelectSocket().GetSocketDescriptor());
       if (gateway.HasBytesToOutput())
       {
          // We only care about the TCP socket's ready-for-write status if our gateway
          // actually has some data queued up to send.  Otherwise there is no point waking up
          // just because the TCP socket's output-buffer isn't full...
-         sm.RegisterSocketForWriteReady(gateway.GetDataIO()()->GetWriteSelectSocket().GetFileDescriptor());
+         sm.RegisterSocketForWriteReady(gateway.GetDataIO()()->GetWriteSelectSocket().GetSocketDescriptor());
       }
     
       // Wait for something to happen (on either the TCP side or the stdin side)...
       sm.WaitForEvents();
 
       // Are there bytes ready-for-read on stdin?
-      if (sm.IsSocketReadyForRead(stdinIO.GetReadSelectSocket().GetFileDescriptor()))
+      if (sm.IsSocketReadyForRead(stdinIO.GetReadSelectSocket().GetSocketDescriptor()))
       {
          // The user typed something in to stdin!  Let's find out what he says
          char buf[1024];
@@ -155,7 +155,7 @@ int main(int argc, char ** argv)
       }
 
       // Are there bytes ready-for-read on the TCP socket?
-      if (sm.IsSocketReadyForRead(gateway.GetDataIO()()->GetReadSelectSocket().GetFileDescriptor()))
+      if (sm.IsSocketReadyForRead(gateway.GetDataIO()()->GetReadSelectSocket().GetSocketDescriptor()))
       {
          // There are some!  Let's have the gateway read them in.  If the gateway
          // has enough to assemble a complete Message out of them, it will call 
@@ -190,7 +190,7 @@ int main(int argc, char ** argv)
 
       // And finally, if there is buffer space for output on the TCP socket,
       // then we should call DoOutput() on the gateway to allow it to send some data
-      if (sm.IsSocketReadyForWrite(gateway.GetDataIO()()->GetWriteSelectSocket().GetFileDescriptor()))
+      if (sm.IsSocketReadyForWrite(gateway.GetDataIO()()->GetWriteSelectSocket().GetSocketDescriptor()))
       {
          int numBytesSent;
          while((numBytesSent = gateway.DoOutput()) > 0)

--- a/html/muscle-by-example/examples/iogateway/example_4_text_to_tcp.cpp
+++ b/html/muscle-by-example/examples/iogateway/example_4_text_to_tcp.cpp
@@ -110,21 +110,21 @@ int main(int argc, char ** argv)
    while(keepGoing)
    {
       // Tell the SocketMultiplexer what file descriptors to watch
-      sm.RegisterSocketForReadReady(stdinIO.GetReadSelectSocket().GetFileDescriptor());
-      sm.RegisterSocketForReadReady(gateway.GetDataIO()()->GetReadSelectSocket().GetFileDescriptor());
+      sm.RegisterSocketForReadReady(stdinIO.GetReadSelectSocket().GetSocketDescriptor());
+      sm.RegisterSocketForReadReady(gateway.GetDataIO()()->GetReadSelectSocket().GetSocketDescriptor());
       if (gateway.HasBytesToOutput())
       {
          // We only care about the TCP socket's ready-for-write status if our gateway
          // actually has some data queued up to send.  Otherwise there is no point waking up
          // just because the TCP socket's output-buffer isn't full...
-         sm.RegisterSocketForWriteReady(gateway.GetDataIO()()->GetWriteSelectSocket().GetFileDescriptor());
+         sm.RegisterSocketForWriteReady(gateway.GetDataIO()()->GetWriteSelectSocket().GetSocketDescriptor());
       }
     
       // Wait for something to happen (on either the TCP side or the stdin side)...
       sm.WaitForEvents();
 
       // Are there bytes ready-for-read on stdin?
-      if (sm.IsSocketReadyForRead(stdinIO.GetReadSelectSocket().GetFileDescriptor()))
+      if (sm.IsSocketReadyForRead(stdinIO.GetReadSelectSocket().GetSocketDescriptor()))
       {
          // The user typed something in to stdin!  Let's find out what he says
          char buf[1024];
@@ -154,7 +154,7 @@ int main(int argc, char ** argv)
       }
 
       // Are there bytes ready-for-read on the TCP socket?
-      if (sm.IsSocketReadyForRead(gateway.GetDataIO()()->GetReadSelectSocket().GetFileDescriptor()))
+      if (sm.IsSocketReadyForRead(gateway.GetDataIO()()->GetReadSelectSocket().GetSocketDescriptor()))
       {
          // There are some!  Let's have the gateway read them in.  If the gateway
          // has enough to assemble a complete Message out of them, it will call 
@@ -189,7 +189,7 @@ int main(int argc, char ** argv)
 
       // And finally, if there is buffer space for output on the TCP socket,
       // then we should call DoOutput() on the gateway to allow it to send some data
-      if (sm.IsSocketReadyForWrite(gateway.GetDataIO()()->GetWriteSelectSocket().GetFileDescriptor()))
+      if (sm.IsSocketReadyForWrite(gateway.GetDataIO()()->GetWriteSelectSocket().GetSocketDescriptor()))
       {
          int numBytesSent;
          while((numBytesSent = gateway.DoOutput()) > 0)

--- a/html/muscle-by-example/examples/messagetransceiverthread/example_1_threaded_smart_client.cpp
+++ b/html/muscle-by-example/examples/messagetransceiverthread/example_1_threaded_smart_client.cpp
@@ -201,12 +201,12 @@ int main(int argc, char ** argv)
    SocketMultiplexer sm;
    while(true)
    {
-      sm.RegisterSocketForReadReady(stdinIO.GetReadSelectSocket().GetFileDescriptor());
-      sm.RegisterSocketForReadReady(mtt.GetOwnerWakeupSocket().GetFileDescriptor());
+      sm.RegisterSocketForReadReady(stdinIO.GetReadSelectSocket().GetSocketDescriptor());
+      sm.RegisterSocketForReadReady(mtt.GetOwnerWakeupSocket().GetSocketDescriptor());
 
       sm.WaitForEvents();
 
-      if (sm.IsSocketReadyForRead(stdinIO.GetReadSelectSocket().GetFileDescriptor()))
+      if (sm.IsSocketReadyForRead(stdinIO.GetReadSelectSocket().GetSocketDescriptor()))
       {
          // Handle stdin input, and send a Message to the MessageTransceiverThread
          // for it to send on to the server, if appropriate
@@ -229,7 +229,7 @@ int main(int argc, char ** argv)
          else if (numBytesRead < 0) break;
       }
 
-      if (sm.IsSocketReadyForRead(mtt.GetOwnerWakeupSocket().GetFileDescriptor()))
+      if (sm.IsSocketReadyForRead(mtt.GetOwnerWakeupSocket().GetSocketDescriptor()))
       {
          // Handle any feedback events sent back to us from the MessageTransceiverThread
          uint32 code;

--- a/html/muscle-by-example/examples/networkutilityfunctions/example_3_udp_multicast.cpp
+++ b/html/muscle-by-example/examples/networkutilityfunctions/example_3_udp_multicast.cpp
@@ -86,7 +86,7 @@ int main(int argc, char ** argv)
    SocketMultiplexer sm;
    while(true)
    {
-      for (HashtableIterator<ConstSocketRef, int> iter(udpSocks); iter.HasData(); iter++) sm.RegisterSocketForReadReady(iter.GetKey().GetFileDescriptor());
+      for (HashtableIterator<ConstSocketRef, int> iter(udpSocks); iter.HasData(); iter++) sm.RegisterSocketForReadReady(iter.GetKey().GetSocketDescriptor());
       (void) sm.WaitForEvents(nextPingTime);
 
       const uint64 now = GetRunTime64();
@@ -99,9 +99,9 @@ int main(int argc, char ** argv)
             const int numBytesSent = SendDataUDP(iter.GetKey(), pingData(), pingData.FlattenedSize(), true, destAddr, multicastGroup.GetPort());
             if (numBytesSent == pingData.FlattenedSize()) 
             {
-               LogTime(MUSCLE_LOG_INFO, "Sent %i-byte multicast packet to [%s] on socket #%i: [%s]\n", numBytesSent, destAddr.ToString()(), iter.GetKey().GetFileDescriptor(), pingData());
+               LogTime(MUSCLE_LOG_INFO, "Sent %i-byte multicast packet to [%s] on socket #" SOCKET_FORMAT_SPEC ": [%s]\n", numBytesSent, destAddr.ToString()(), iter.GetKey().GetSocketDescriptor(), pingData());
             }
-            else LogTime(MUSCLE_LOG_ERROR, "Error sending multicast ping to socket %i\n", iter.GetKey().GetFileDescriptor());
+            else LogTime(MUSCLE_LOG_ERROR, "Error sending multicast ping to socket " SOCKET_FORMAT_SPEC "\n", iter.GetKey().GetSocketDescriptor());
          }
 
          nextPingTime += SecondsToMicros(5);
@@ -109,7 +109,7 @@ int main(int argc, char ** argv)
 
       for (HashtableIterator<ConstSocketRef, int> iter(udpSocks); iter.HasData(); iter++)
       {
-         if (sm.IsSocketReadyForRead(iter.GetKey().GetFileDescriptor()))
+         if (sm.IsSocketReadyForRead(iter.GetKey().GetSocketDescriptor()))
          {
             char recvBuf[1024];
             int numBytesReceived;

--- a/html/muscle-by-example/examples/reflector/example_3_annotated_dumb_server.cpp
+++ b/html/muscle-by-example/examples/reflector/example_3_annotated_dumb_server.cpp
@@ -46,7 +46,7 @@ public:
    virtual ConstSocketRef CreateDefaultSocket()
    {
       ConstSocketRef ret = DumbReflectSession::CreateDefaultSocket();
-      LogTime(MUSCLE_LOG_INFO, "MyDumbReflectSession(%p)::CreateDefaultSocket() called -- returning %p (socket_fd=%i)\n", this, ret(), ret.GetFileDescriptor());
+      LogTime(MUSCLE_LOG_INFO, "MyDumbReflectSession(%p)::CreateDefaultSocket() called -- returning %p (socket_fd=" SOCKET_FORMAT_SPEC ")\n", this, ret(), ret.GetSocketDescriptor());
       return ret;
    }
 

--- a/html/muscle-by-example/examples/socket/example_1_basic_usage.cpp
+++ b/html/muscle-by-example/examples/socket/example_1_basic_usage.cpp
@@ -20,7 +20,7 @@ int main(int argc, char ** argv)
    // Atypical usage:  Capturing a file descriptor into a Socket object so that
    // it will be automatically close()'d when the execution leaves the enclosing scope
    {
-      int some_fd = socket(AF_INET, SOCK_DGRAM, 0);
+      SocketDescriptor some_fd = socket(AF_INET, SOCK_DGRAM, 0);
       Socket mySock(some_fd);
       // [...]
       // close(some_fd) will automatically be called here by the Socket object's destructor 
@@ -45,7 +45,7 @@ int main(int argc, char ** argv)
       ConstSocketRef sockRef = CreateUDPSocket();  // returns a ready-to-use UDP socket
       if (sockRef())
       {
-         printf("Allocated UDP socket ref:  ConstSocketRef=%p, underlying fd is %i\n", sockRef(), sockRef.GetFileDescriptor());
+         printf("Allocated UDP socket ref:  ConstSocketRef=%p, underlying descriptor is " SOCKET_FORMAT_SPEC "\n", sockRef(), sockRef.GetSocketDescriptor());
 
          // Code using the UDP socket could go here
          // [...]

--- a/html/muscle-by-example/examples/socketmultiplexer/example_1_tcp_echo_server.cpp
+++ b/html/muscle-by-example/examples/socketmultiplexer/example_1_tcp_echo_server.cpp
@@ -50,12 +50,12 @@ int main(int argc, char ** argv)
    while(true)
    {
       // Register our acceptSock so we'll know if a new TCP connection comes in
-      (void) socketMux.RegisterSocketForReadReady(acceptSock.GetFileDescriptor());
+      (void) socketMux.RegisterSocketForReadReady(acceptSock.GetSocketDescriptor());
 
       // Register our client-sockets so we'll know if any of them send us data
       for (HashtableIterator<ConstSocketRef, Void> iter(connectedClients); iter.HasData(); iter++)
       {
-         (void) socketMux.RegisterSocketForReadReady(iter.GetKey().GetFileDescriptor());
+         (void) socketMux.RegisterSocketForReadReady(iter.GetKey().GetSocketDescriptor());
       }
 
       // Block here until there is something to do
@@ -66,14 +66,14 @@ int main(int argc, char ** argv)
       printf("WaitForEvents() returned after %s\n", GetHumanReadableTimeIntervalString(nowAfterWaitMicros-nowBeforeWaitMicros)());
  
       // See if any new TCP connection requests have come in
-      if (socketMux.IsSocketReadyForRead(acceptSock.GetFileDescriptor()))
+      if (socketMux.IsSocketReadyForRead(acceptSock.GetSocketDescriptor()))
       {
          printf("SocketMultiplexer thinks that the acceptSock is ready-for-read now!\n");
 
          ConstSocketRef newClientSock = Accept(acceptSock);
          if (newClientSock())
          {
-            printf("Accepted new incoming TCP connection, socket is %p, file descriptor %i\n", newClientSock(), newClientSock.GetFileDescriptor());
+            printf("Accepted new incoming TCP connection, socket is %p, socket descriptor " SOCKET_FORMAT_SPEC "\n", newClientSock(), newClientSock.GetSocketDescriptor());
             (void) connectedClients.PutWithDefault(newClientSock);
          }
          else printf("Error, Accept() failed!\n");
@@ -83,17 +83,17 @@ int main(int argc, char ** argv)
       for (HashtableIterator<ConstSocketRef, Void> iter(connectedClients); iter.HasData(); iter++)
       {
          const ConstSocketRef & clientSock = iter.GetKey();
-         if (socketMux.IsSocketReadyForRead(clientSock.GetFileDescriptor()))
+         if (socketMux.IsSocketReadyForRead(clientSock.GetSocketDescriptor()))
          {
-            printf("Socket %p (file descriptor %i) reports ready-for-read...\n", clientSock(), clientSock.GetFileDescriptor());
+            printf("Socket %p (socket descriptor " SOCKET_FORMAT_SPEC ") reports ready-for-read...\n", clientSock(), clientSock.GetSocketDescriptor());
 
             uint8 tempBuf[1024];
             const int numBytesRead = ReceiveData(clientSock, tempBuf, sizeof(tempBuf), true);  // true because we're using blocking I/O
             if (numBytesRead >= 0)   // Note that unlike recv(), ReceiveData() returning 0 doesn't mean connection-closed
             {
-               printf("Read %i bytes from socket %i, echoing them back...\n", numBytesRead, clientSock.GetFileDescriptor());
+               printf("Read %i bytes from socket " SOCKET_FORMAT_SPEC ", echoing them back...\n", numBytesRead, clientSock.GetSocketDescriptor());
                const int numBytesWritten = SendData(clientSock, tempBuf, numBytesRead, true);   // true because we're using blocking I/O
-               printf("Wrote %i/%i bytes back to socket %i\n", numBytesWritten, numBytesRead, clientSock.GetFileDescriptor());
+               printf("Wrote %i/%i bytes back to socket " SOCKET_FORMAT_SPEC "\n", numBytesWritten, numBytesRead, clientSock.GetSocketDescriptor());
             }
             else
             {

--- a/iogateway/MessageIOGateway.cpp
+++ b/iogateway/MessageIOGateway.cpp
@@ -529,7 +529,7 @@ MessageRef MessageIOGateway :: CreateSynchronousPingMessage(uint32 syncPingCount
 status_t MessageIOGateway :: ExecuteSynchronousMessaging(AbstractGatewayMessageReceiver * optReceiver, uint64 timeoutPeriod)
 {
    const DataIO * dio = GetDataIO()();
-   if ((dio == NULL)||(dio->GetReadSelectSocket().GetFileDescriptor() < 0)||(dio->GetWriteSelectSocket().GetFileDescriptor() < 0)) return B_BAD_OBJECT;
+   if ((dio == NULL)||(!isValidSocket(dio->GetReadSelectSocket().GetSocketDescriptor()))||(!isValidSocket(dio->GetWriteSelectSocket().GetSocketDescriptor()))) return B_BAD_OBJECT;
 
    MessageRef pingMsg = CreateSynchronousPingMessage(_syncPingCounter);
    if (pingMsg() == NULL) return B_ERROR("CreateSynchronousPingMessage() failed");

--- a/qtsupport/QSignalHandler.cpp
+++ b/qtsupport/QSignalHandler.cpp
@@ -14,7 +14,7 @@ QSignalHandler :: QSignalHandler(QObject * parent, const char * name)
    status_t ret;
    if ((CreateConnectedSocketPair(_mainThreadSocket, _handlerFuncSocket).IsOK(ret))&&(SignalMultiplexer::GetSignalMultiplexer().AddHandler(this).IsOK(ret)))
    {
-      _socketNotifier = new QSocketNotifier(_mainThreadSocket.GetFileDescriptor(), QSocketNotifier::Read, this);
+      _socketNotifier = new QSocketNotifier(_mainThreadSocket.GetSocketDescriptor(), QSocketNotifier::Read, this);
       connect(_socketNotifier, SIGNAL(activated(int)), this, SLOT(SocketDataReady()));
    }
    else LogTime(MUSCLE_LOG_CRITICALERROR, "QSignalHandler %p could not register with the SignalMultiplexer! [%s]\n", this, ret());

--- a/qtsupport/qt_muscled/qt_muscled.cpp
+++ b/qtsupport/qt_muscled/qt_muscled.cpp
@@ -35,7 +35,7 @@ MuscledWindow :: MuscledWindow(const char * argv0)
    if (_cpdio.LaunchChildProcess(argv).IsOK()) 
    {
       _gateway.SetDataIO(DummyDataIORef(_cpdio));
-      _notifier = new QSocketNotifier(_cpdio.GetReadSelectSocket().GetFileDescriptor(), QSocketNotifier::Read, this);
+      _notifier = new QSocketNotifier(_cpdio.GetReadSelectSocket().GetSocketDescriptor(), QSocketNotifier::Read, this);
       connect(_notifier, SIGNAL(activated(int)), this, SLOT(TextAvailableFromChildProcess()));
    }
    else _muscledStdoutText->appendPlainText("<Error launching muscled sub-process!>\r\n");

--- a/reflector/StorageReflectSession.cpp
+++ b/reflector/StorageReflectSession.cpp
@@ -2005,7 +2005,7 @@ void StorageReflectSession :: PrintSessionsInfo() const
       if (ars->HasBytesToOutput()) stateStr = stateStr.AppendWord("HasBytesToOutput", ", ");
       if (ars->WasConnected()) stateStr = stateStr.AppendWord("WasConnected", ", ");
       if (stateStr.HasChars()) stateStr = stateStr.Prepend(", ");
-      printf("  Session [%s] (rfd=%i,wfd=%i) is [%s]:  (" UINT32_FORMAT_SPEC " outgoing Messages, " UINT32_FORMAT_SPEC " Message-bytes, " UINT32_FORMAT_SPEC " nodes, " UINT32_FORMAT_SPEC " node-bytes%s)\n", iter.GetKey()->Cstr(), ars->GetSessionReadSelectSocket().GetFileDescriptor(), ars->GetSessionWriteSelectSocket().GetFileDescriptor(), ars->GetSessionDescriptionString()(), numOutMessages, numOutBytes, numNodes, numNodeBytes, stateStr());
+      printf("  Session [%s] (rsd=" SOCKET_FORMAT_SPEC ",wsd=" SOCKET_FORMAT_SPEC ") is [%s]:  (" UINT32_FORMAT_SPEC " outgoing Messages, " UINT32_FORMAT_SPEC " Message-bytes, " UINT32_FORMAT_SPEC " nodes, " UINT32_FORMAT_SPEC " node-bytes%s)\n", iter.GetKey()->Cstr(), ars->GetSessionReadSelectSocket().GetSocketDescriptor(), ars->GetSessionWriteSelectSocket().GetSocketDescriptor(), ars->GetSessionDescriptionString()(), numOutMessages, numOutBytes, numNodes, numNodeBytes, stateStr());
       totalNumOutMessages += numOutMessages;
       totalNumOutBytes    += numOutBytes;
       totalNumNodes       += numNodes;

--- a/system/AcceptSocketsThread.cpp
+++ b/system/AcceptSocketsThread.cpp
@@ -42,7 +42,7 @@ status_t AcceptSocketsThread :: StartInternalThread()
    if ((IsInternalThreadRunning() == false)&&(_acceptSocket()))
    {
       _notifySocket = GetInternalThreadWakeupSocket();
-      return (_notifySocket.GetFileDescriptor() >= 0) ? Thread::StartInternalThread() : B_BAD_OBJECT;
+      return isValidSocket(_notifySocket.GetSocketDescriptor()) ? Thread::StartInternalThread() : B_BAD_OBJECT;
    } 
    return B_BAD_OBJECT;
 }
@@ -53,13 +53,13 @@ void AcceptSocketsThread :: InternalThreadEntry()
    bool keepGoing = true;
    while(keepGoing)
    {
-      const int afd = _acceptSocket.GetFileDescriptor();
-      const int nfd = _notifySocket.GetFileDescriptor();
+      const SocketDescriptor asd = _acceptSocket.GetSocketDescriptor();
+      const SocketDescriptor nsd = _notifySocket.GetSocketDescriptor();
 
-      multiplexer.RegisterSocketForReadReady(afd);
-      multiplexer.RegisterSocketForReadReady(nfd);
+      multiplexer.RegisterSocketForReadReady(asd);
+      multiplexer.RegisterSocketForReadReady(nsd);
       if (multiplexer.WaitForEvents() < 0) break;
-      if (multiplexer.IsSocketReadyForRead(nfd))
+      if (multiplexer.IsSocketReadyForRead(nsd))
       {
          MessageRef msgRef;
          int32 numLeft;
@@ -72,7 +72,7 @@ void AcceptSocketsThread :: InternalThreadEntry()
             }
          }
       }
-      if (multiplexer.IsSocketReadyForRead(afd))
+      if (multiplexer.IsSocketReadyForRead(asd))
       {
          ConstSocketRef newSocket = Accept(_acceptSocket);
          if (newSocket())

--- a/system/DetectNetworkConfigChangesSession.h
+++ b/system/DetectNetworkConfigChangesSession.h
@@ -116,7 +116,7 @@ private:
 
       // send a byte on the socket-pair to wake up the user thread so he'll check his _messagesFromSingletonThread queue
       const char junk = 'S';
-      (void) send_ignore_eintr(_notifySocket.GetFileDescriptor(), &junk, sizeof(junk), 0);
+      (void) send_ignore_eintr(_notifySocket.GetSocketDescriptor(), &junk, sizeof(junk), 0);
       return B_NO_ERROR;
    }
    Mutex _messagesFromSingletonThreadMutex;

--- a/test/bandwidthtester.cpp
+++ b/test/bandwidthtester.cpp
@@ -47,9 +47,9 @@ int main(int argc, char ** argv)
    QueueGatewayMessageReceiver inQueue;
    while(true)
    {
-      const int fd = s.GetFileDescriptor();
-      multiplexer.RegisterSocketForReadReady(fd);
-      if ((send)||(gw.HasBytesToOutput())) multiplexer.RegisterSocketForWriteReady(fd);
+      const SocketDescriptor sd = s.GetSocketDescriptor();
+      multiplexer.RegisterSocketForReadReady(sd);
+      if ((send)||(gw.HasBytesToOutput())) multiplexer.RegisterSocketForWriteReady(sd);
 
       const struct timeval printInterval = {5, 0};
       if (OnceEvery(printInterval, lastPrintTime))
@@ -72,8 +72,8 @@ int main(int argc, char ** argv)
 
       if (multiplexer.WaitForEvents() < 0) LogTime(MUSCLE_LOG_CRITICALERROR, "bandwidthtester: WaitForEvents() failed! [%s]\n", B_ERRNO());
       if ((send)&&(gw.HasBytesToOutput() == false)) for (int i=0; i<10; i++) (void) gw.AddOutgoingMessage(sendMsgRef);
-      const bool reading = multiplexer.IsSocketReadyForRead(fd);
-      const bool writing = multiplexer.IsSocketReadyForWrite(fd);
+      const bool reading = multiplexer.IsSocketReadyForRead(sd);
+      const bool writing = multiplexer.IsSocketReadyForWrite(sd);
       const int32 wroteBytes = (writing) ? gw.DoOutput() : 0;
       const int32 readBytes  = (reading) ? gw.DoInput(inQueue) : 0;
       if ((readBytes < 0)||(wroteBytes < 0))

--- a/test/chatclient.cpp
+++ b/test/chatclient.cpp
@@ -132,7 +132,7 @@ int main(int argc, char ** argv)
    QueueGatewayMessageReceiver stdinInQueue;
    PlainTextMessageIOGateway stdinGateway;
    stdinGateway.SetDataIO(DummyDataIORef(stdinIO));
-   const int stdinFD = stdinIO.GetReadSelectSocket().GetFileDescriptor();
+   const SocketDescriptor stdinSD = stdinIO.GetReadSelectSocket().GetSocketDescriptor();
 
    // Our event loop
    Hashtable<String, String> _users;
@@ -140,10 +140,10 @@ int main(int argc, char ** argv)
    SocketMultiplexer multiplexer;
    while(s())
    {
-      const int fd = s.GetFileDescriptor();
-      multiplexer.RegisterSocketForReadReady(fd);
-      if (gw.HasBytesToOutput()) multiplexer.RegisterSocketForWriteReady(fd);
-      multiplexer.RegisterSocketForReadReady(stdinFD);
+      const SocketDescriptor sd = s.GetSocketDescriptor();
+      multiplexer.RegisterSocketForReadReady(sd);
+      if (gw.HasBytesToOutput()) multiplexer.RegisterSocketForWriteReady(sd);
+      multiplexer.RegisterSocketForReadReady(stdinSD);
 
       while(s()) 
       {
@@ -154,7 +154,7 @@ int main(int argc, char ** argv)
             break;
          }
 
-         if (multiplexer.IsSocketReadyForRead(stdinFD))
+         if (multiplexer.IsSocketReadyForRead(stdinSD))
          {
             while(1)
             {
@@ -215,8 +215,8 @@ int main(int argc, char ** argv)
             }
          }
 
-         const bool reading = multiplexer.IsSocketReadyForRead(fd);
-         const bool writing = multiplexer.IsSocketReadyForWrite(fd);
+         const bool reading = multiplexer.IsSocketReadyForRead(sd);
+         const bool writing = multiplexer.IsSocketReadyForWrite(sd);
          const bool writeError = ((writing)&&(gw.DoOutput() < 0));
          const bool readError  = ((reading)&&(gw.DoInput(inQueue) < 0));
          if ((readError)||(writeError))
@@ -341,9 +341,9 @@ int main(int argc, char ** argv)
 
          if ((reading == false)&&(writing == false)) break;
 
-         multiplexer.RegisterSocketForReadReady(stdinFD);
-         multiplexer.RegisterSocketForReadReady(fd);
-         if (gw.HasBytesToOutput()) multiplexer.RegisterSocketForWriteReady(fd);
+         multiplexer.RegisterSocketForReadReady(stdinSD);
+         multiplexer.RegisterSocketForReadReady(sd);
+         if (gw.HasBytesToOutput()) multiplexer.RegisterSocketForWriteReady(sd);
       }
    } 
 

--- a/test/portableplaintextclient.cpp
+++ b/test/portableplaintextclient.cpp
@@ -34,23 +34,23 @@ int main(int argc, char ** argv)
    QueueGatewayMessageReceiver stdinInQueue;
    PlainTextMessageIOGateway stdinGateway;
    stdinGateway.SetDataIO(DummyDataIORef(stdinIO));
-   const int stdinFD = stdinIO.GetReadSelectSocket().GetFileDescriptor();
+   const SocketDescriptor stdinSD = stdinIO.GetReadSelectSocket().GetSocketDescriptor();
 
    SocketMultiplexer multiplexer;
    PlainTextMessageIOGateway gw;
    gw.SetDataIO(DataIORef(new TCPSocketDataIO(s, false)));
    while(s())
    {
-      const int fd = s.GetFileDescriptor();
-      multiplexer.RegisterSocketForReadReady(fd);
-      if (gw.HasBytesToOutput()) multiplexer.RegisterSocketForWriteReady(fd);
-      multiplexer.RegisterSocketForReadReady(stdinFD);
+      const SocketDescriptor sd = s.GetSocketDescriptor();
+      multiplexer.RegisterSocketForReadReady(sd);
+      if (gw.HasBytesToOutput()) multiplexer.RegisterSocketForWriteReady(sd);
+      multiplexer.RegisterSocketForReadReady(stdinSD);
 
       QueueGatewayMessageReceiver inQueue;
       while(s()) 
       {
          if (multiplexer.WaitForEvents() < 0) printf("portablereflectclient: WaitForEvents() failed!\n");
-         if (multiplexer.IsSocketReadyForRead(stdinFD))
+         if (multiplexer.IsSocketReadyForRead(stdinSD))
          {
             while(1)
             {
@@ -79,8 +79,8 @@ int main(int argc, char ** argv)
             }
          }
    
-         const bool reading = multiplexer.IsSocketReadyForRead(fd);
-         const bool writing = multiplexer.IsSocketReadyForWrite(fd);
+         const bool reading = multiplexer.IsSocketReadyForRead(sd);
+         const bool writing = multiplexer.IsSocketReadyForWrite(sd);
          const bool writeError = ((writing)&&(gw.DoOutput() < 0));
          const bool readError  = ((reading)&&(gw.DoInput(inQueue) < 0));
          if ((readError)||(writeError))
@@ -101,9 +101,9 @@ int main(int argc, char ** argv)
 
          if ((reading == false)&&(writing == false)) break;
 
-         multiplexer.RegisterSocketForReadReady(fd);
-         if (gw.HasBytesToOutput()) multiplexer.RegisterSocketForWriteReady(fd);
-         multiplexer.RegisterSocketForReadReady(stdinFD);
+         multiplexer.RegisterSocketForReadReady(sd);
+         if (gw.HasBytesToOutput()) multiplexer.RegisterSocketForWriteReady(sd);
+         multiplexer.RegisterSocketForReadReady(stdinSD);
       }
    }
 

--- a/test/portablereflectclient.cpp
+++ b/test/portablereflectclient.cpp
@@ -108,13 +108,13 @@ int main(int argc, char ** argv)
    uint64 nextTimeoutTime = MUSCLE_TIME_NEVER;
    while(keepGoing)
    {
-      const int stdinFD       = stdinIO.GetReadSelectSocket().GetFileDescriptor();
-      const int socketReadFD  = networkIORef()->GetReadSelectSocket().GetFileDescriptor();
-      const int socketWriteFD = networkIORef()->GetWriteSelectSocket().GetFileDescriptor();
+      const SocketDescriptor stdinSD       = stdinIO.GetReadSelectSocket().GetSocketDescriptor();
+      const SocketDescriptor socketReadSD  = networkIORef()->GetReadSelectSocket().GetSocketDescriptor();
+      const SocketDescriptor socketWriteSD = networkIORef()->GetWriteSelectSocket().GetSocketDescriptor();
 
-      multiplexer.RegisterSocketForReadReady(stdinFD);
-      multiplexer.RegisterSocketForReadReady(socketReadFD);
-      if (gatewayRef()->HasBytesToOutput()) multiplexer.RegisterSocketForWriteReady(socketWriteFD);
+      multiplexer.RegisterSocketForReadReady(stdinSD);
+      multiplexer.RegisterSocketForReadReady(socketReadSD);
+      if (gatewayRef()->HasBytesToOutput()) multiplexer.RegisterSocketForWriteReady(socketWriteSD);
       if (multiplexer.WaitForEvents(nextTimeoutTime) < 0) printf("portablereflectclient: WaitForEvents() failed!\n");
 
       const uint64 now = GetRunTime64();
@@ -135,7 +135,7 @@ int main(int argc, char ** argv)
       }
 
       // Receive data from stdin
-      if (multiplexer.IsSocketReadyForRead(stdinFD))
+      if (multiplexer.IsSocketReadyForRead(stdinSD))
       {
          while(1)
          {
@@ -317,8 +317,8 @@ int main(int argc, char ** argv)
       }
 
       // Handle input and output on the TCP socket
-      const bool reading = multiplexer.IsSocketReadyForRead(socketReadFD);
-      const bool writing = multiplexer.IsSocketReadyForWrite(socketWriteFD);
+      const bool reading = multiplexer.IsSocketReadyForRead(socketReadSD);
+      const bool writing = multiplexer.IsSocketReadyForWrite(socketWriteSD);
       const bool writeError = ((writing)&&(gatewayRef()->DoOutput() < 0));
       const bool readError  = ((reading)&&(gatewayRef()->DoInput(tcpInQueue) < 0));
       if ((readError)||(writeError))

--- a/test/serialproxy.cpp
+++ b/test/serialproxy.cpp
@@ -15,7 +15,7 @@ static const int DEFAULT_PORT = 5274;  // What CueStation 2.5 connects to by def
 
 static status_t ReadIncomingData(const char * desc, DataIO & readIO, const SocketMultiplexer & multiplexer, Queue<ByteBufferRef> & outQ)
 {
-   if (multiplexer.IsSocketReadyForRead(readIO.GetReadSelectSocket().GetFileDescriptor()))
+   if (multiplexer.IsSocketReadyForRead(readIO.GetReadSelectSocket().GetSocketDescriptor()))
    {
       uint8 buf[4096];
       const int32 ret = readIO.Read(buf, sizeof(buf));
@@ -34,7 +34,7 @@ static status_t ReadIncomingData(const char * desc, DataIO & readIO, const Socke
 
 static status_t WriteOutgoingData(const char * desc, DataIO & writeIO, const SocketMultiplexer & multiplexer, Queue<ByteBufferRef> & outQ, uint32 & writeIdx)
 {
-   if (multiplexer.IsSocketReadyForWrite(writeIO.GetWriteSelectSocket().GetFileDescriptor()))
+   if (multiplexer.IsSocketReadyForWrite(writeIO.GetWriteSelectSocket().GetSocketDescriptor()))
    {
       while(outQ.HasItems())
       {
@@ -70,16 +70,16 @@ static status_t DoSession(DataIO & networkIO, DataIO & serialIO)
    SocketMultiplexer multiplexer;
    while(true)
    {
-      const int networkReadFD  = networkIO.GetReadSelectSocket().GetFileDescriptor();
-      const int serialReadFD   = serialIO.GetReadSelectSocket().GetFileDescriptor();
-      const int networkWriteFD = networkIO.GetWriteSelectSocket().GetFileDescriptor();
-      const int serialWriteFD  = serialIO.GetWriteSelectSocket().GetFileDescriptor();
+      const SocketDescriptor networkReadSD  = networkIO.GetReadSelectSocket().GetSocketDescriptor();
+      const SocketDescriptor serialReadSD   = serialIO.GetReadSelectSocket().GetSocketDescriptor();
+      const SocketDescriptor networkWriteSD = networkIO.GetWriteSelectSocket().GetSocketDescriptor();
+      const SocketDescriptor serialWriteSD  = serialIO.GetWriteSelectSocket().GetSocketDescriptor();
 
-      multiplexer.RegisterSocketForReadReady(networkReadFD);
-      multiplexer.RegisterSocketForReadReady(serialReadFD);
+      multiplexer.RegisterSocketForReadReady(networkReadSD);
+      multiplexer.RegisterSocketForReadReady(serialReadSD);
 
-      if (outgoingNetworkData.HasItems()) multiplexer.RegisterSocketForWriteReady(networkWriteFD);
-      if (outgoingSerialData.HasItems())  multiplexer.RegisterSocketForWriteReady(serialWriteFD);
+      if (outgoingNetworkData.HasItems()) multiplexer.RegisterSocketForWriteReady(networkWriteSD);
+      if (outgoingSerialData.HasItems())  multiplexer.RegisterSocketForWriteReady(serialWriteSD);
 
       if (multiplexer.WaitForEvents() >= 0)
       {

--- a/test/testnagle.cpp
+++ b/test/testnagle.cpp
@@ -19,9 +19,9 @@ void HandleSession(const ConstSocketRef & sock, bool myTurnToThrow, bool doFlush
    SocketMultiplexer multiplexer;
    while(1)
    {
-      const int fd = sock.GetFileDescriptor();
-      multiplexer.RegisterSocketForReadReady(fd);
-      if (myTurnToThrow) multiplexer.RegisterSocketForWriteReady(fd);
+      const SocketDescriptor sd = sock.GetSocketDescriptor();
+      multiplexer.RegisterSocketForReadReady(sd);
+      if (myTurnToThrow) multiplexer.RegisterSocketForWriteReady(sd);
 
       if (multiplexer.WaitForEvents() < 0)
       {
@@ -29,7 +29,7 @@ void HandleSession(const ConstSocketRef & sock, bool myTurnToThrow, bool doFlush
          break;
       }
 
-      if ((myTurnToThrow)&&(multiplexer.IsSocketReadyForWrite(fd)))
+      if ((myTurnToThrow)&&(multiplexer.IsSocketReadyForWrite(sd)))
       {
          const int32 bytesWritten = sockIO.Write(&ball, sizeof(ball));
          if (bytesWritten == sizeof(ball))
@@ -45,7 +45,7 @@ void HandleSession(const ConstSocketRef & sock, bool myTurnToThrow, bool doFlush
          }
       }
 
-      if (multiplexer.IsSocketReadyForRead(fd))
+      if (multiplexer.IsSocketReadyForRead(sd))
       {
          const int32 bytesRead = sockIO.Read(&ball, sizeof(ball));
          if (bytesRead == sizeof(ball))

--- a/test/testpackettunnel.cpp
+++ b/test/testpackettunnel.cpp
@@ -159,18 +159,18 @@ int main(int argc, char ** argv)
 
    uint64 nextSpamTime = 0;
    LogTime(MUSCLE_LOG_INFO, "%s Event loop starting [%s]...\n", useTCP?"TCP":"UDP", (spamInterval>0) ? "Broadcast mode" : "Receive mode");
-   const int readFD  = dio()->GetReadSelectSocket().GetFileDescriptor();
-   const int writeFD = dio()->GetWriteSelectSocket().GetFileDescriptor();
+   const SocketDescriptor readSD  = dio()->GetReadSelectSocket().GetSocketDescriptor();
+   const SocketDescriptor writeSD = dio()->GetWriteSelectSocket().GetSocketDescriptor();
    uint64 lastTime = 0;
    while(1)
    {
       if (OnceEvery(MICROS_PER_SECOND, lastTime)) LogTime(MUSCLE_LOG_INFO, "Send counter is currently at " UINT32_FORMAT_SPEC ", Receive counter is currently at " UINT32_FORMAT_SPEC "\n", _sendWhatCounter, _recvWhatCounter);
-      multiplexer.RegisterSocketForReadReady(readFD);
-      if (gw.HasBytesToOutput()) multiplexer.RegisterSocketForWriteReady(writeFD);
+      multiplexer.RegisterSocketForReadReady(readSD);
+      if (gw.HasBytesToOutput()) multiplexer.RegisterSocketForWriteReady(writeSD);
       if (multiplexer.WaitForEvents((spamInterval>0)?nextSpamTime:MUSCLE_TIME_NEVER) < 0) LogTime(MUSCLE_LOG_CRITICALERROR, "testpackettunnel: WaitForEvents() failed!\n");
 
-      const bool reading = multiplexer.IsSocketReadyForRead(readFD);
-      const bool writing = multiplexer.IsSocketReadyForWrite(writeFD);
+      const bool reading = multiplexer.IsSocketReadyForRead(readSD);
+      const bool writing = multiplexer.IsSocketReadyForWrite(writeSD);
       const bool writeError = ((writing)&&(gw.DoOutput() < 0));
       const bool readError  = ((reading)&&(gw.DoInput(receiver) < 0));
       if ((readError)||(writeError))

--- a/test/testresponse.cpp
+++ b/test/testresponse.cpp
@@ -41,15 +41,15 @@ int main(int argc, char ** argv)
                lastThrowTime = GetRunTime64();
             }
 
-            const int fd = s.GetFileDescriptor();
-            multiplexer.RegisterSocketForReadReady(fd);
-            if (ioGateway.HasBytesToOutput()) multiplexer.RegisterSocketForWriteReady(fd);
+            const SocketDescriptor sd = s.GetSocketDescriptor();
+            multiplexer.RegisterSocketForReadReady(sd);
+            if (ioGateway.HasBytesToOutput()) multiplexer.RegisterSocketForWriteReady(sd);
             if (multiplexer.WaitForEvents() < 0)
             {
                LogTime(MUSCLE_LOG_ERROR, "WaitForEvents() failed, aborting! [%s]\n", B_ERRNO());
                break;
             }
-            if (multiplexer.IsSocketReadyForRead(fd))
+            if (multiplexer.IsSocketReadyForRead(sd))
             {
                if (ioGateway.DoInput(inQueue) < 0)
                {
@@ -74,7 +74,7 @@ int main(int argc, char ** argv)
                }
             }
 
-            if ((multiplexer.IsSocketReadyForWrite(fd))&&(ioGateway.DoOutput() < 0))
+            if ((multiplexer.IsSocketReadyForWrite(sd))&&(ioGateway.DoOutput() < 0))
             {
                LogTime(MUSCLE_LOG_ERROR, "Error writing to gateway, aborting!\n");
                break;

--- a/test/testsocketmultiplexer.cpp
+++ b/test/testsocketmultiplexer.cpp
@@ -64,7 +64,7 @@ int main(int argc, char ** argv)
    {
       for (uint32 i=0; i<numPairs; i++)
       {
-         if (multiplexer.RegisterSocketForReadReady(receivers[i].GetFileDescriptor()).IsError())
+         if (multiplexer.RegisterSocketForReadReady(receivers[i].GetSocketDescriptor()).IsError())
          {
             printf("Error, RegisterSocketForRead() failed for receiver #" UINT32_FORMAT_SPEC "!\n", i);
             error = true;
@@ -93,7 +93,7 @@ int main(int argc, char ** argv)
       
       for (uint32 i=0; i<numPairs; i++)
       {
-         if (multiplexer.IsSocketReadyForRead(receivers[i].GetFileDescriptor()))
+         if (multiplexer.IsSocketReadyForRead(receivers[i].GetSocketDescriptor()))
          {
             char buf[64];
             const int32 numBytesReceived = ReceiveData(receivers[i], buf, sizeof(buf), false);

--- a/test/testudp.cpp
+++ b/test/testudp.cpp
@@ -74,22 +74,22 @@ int main(int argc, char ** argv)
    QueueGatewayMessageReceiver stdinInQueue;
    PlainTextMessageIOGateway stdinGateway;
    stdinGateway.SetDataIO(DummyDataIORef(stdinIO));
-   const int stdinFD = stdinIO.GetReadSelectSocket().GetFileDescriptor();
+   const SocketDescriptor stdinSD = stdinIO.GetReadSelectSocket().GetSocketDescriptor();
 
    QueueGatewayMessageReceiver inQueue;
    SocketMultiplexer multiplexer;
    printf("UDP Event loop starting...\n");
    while(s())
    {
-      const int fd = s.GetFileDescriptor();
-      multiplexer.RegisterSocketForReadReady(fd);
-      if (agw()->HasBytesToOutput()) multiplexer.RegisterSocketForWriteReady(fd);
-      multiplexer.RegisterSocketForReadReady(stdinFD);
+      const SocketDescriptor sd = s.GetSocketDescriptor();
+      multiplexer.RegisterSocketForReadReady(sd);
+      if (agw()->HasBytesToOutput()) multiplexer.RegisterSocketForWriteReady(sd);
+      multiplexer.RegisterSocketForReadReady(stdinSD);
 
       while(s())
       {
          if (multiplexer.WaitForEvents() < 0) printf("testudp: WaitForEvents() failed!\n");
-         if (multiplexer.IsSocketReadyForRead(stdinFD))
+         if (multiplexer.IsSocketReadyForRead(stdinSD))
          {
             while(1)
             {
@@ -224,8 +224,8 @@ int main(int argc, char ** argv)
             }
          }
 
-         const bool reading = multiplexer.IsSocketReadyForRead(fd);
-         const bool writing = multiplexer.IsSocketReadyForWrite(fd);
+         const bool reading = multiplexer.IsSocketReadyForRead(sd);
+         const bool writing = multiplexer.IsSocketReadyForWrite(sd);
          const bool writeError = ((writing)&&(agw()->DoOutput() < 0));
          const bool readError  = ((reading)&&(agw()->DoInput(inQueue) < 0));
          if ((readError)||(writeError))
@@ -247,9 +247,9 @@ int main(int argc, char ** argv)
 
          if ((reading == false)&&(writing == false)) break;
 
-         multiplexer.RegisterSocketForReadReady(fd);
-         if (agw()->HasBytesToOutput()) multiplexer.RegisterSocketForWriteReady(fd);
-         multiplexer.RegisterSocketForReadReady(stdinFD);
+         multiplexer.RegisterSocketForReadReady(sd);
+         if (agw()->HasBytesToOutput()) multiplexer.RegisterSocketForWriteReady(sd);
+         multiplexer.RegisterSocketForReadReady(stdinSD);
       }
    }
 

--- a/test/udpproxy.cpp
+++ b/test/udpproxy.cpp
@@ -14,7 +14,7 @@ static const int DEFAULT_PORT = 8000;  // LX-300's default port for OSC
 
 static status_t ReadIncomingData(const String & desc, DataIO & readIO, const SocketMultiplexer & multiplexer, Queue<ByteBufferRef> & outQ)
 {
-   if (multiplexer.IsSocketReadyForRead(readIO.GetReadSelectSocket().GetFileDescriptor()))
+   if (multiplexer.IsSocketReadyForRead(readIO.GetReadSelectSocket().GetSocketDescriptor()))
    {
       uint8 buf[4096];
       const int32 ret = readIO.Read(buf, sizeof(buf));
@@ -33,7 +33,7 @@ static status_t ReadIncomingData(const String & desc, DataIO & readIO, const Soc
 
 static status_t WriteOutgoingData(const String & desc, DataIO & writeIO, const SocketMultiplexer & multiplexer, Queue<ByteBufferRef> & outQ, uint32 & writeIdx)
 {
-   if (multiplexer.IsSocketReadyForWrite(writeIO.GetWriteSelectSocket().GetFileDescriptor()))
+   if (multiplexer.IsSocketReadyForWrite(writeIO.GetWriteSelectSocket().GetSocketDescriptor()))
    {
       while(outQ.HasItems())
       {
@@ -70,15 +70,15 @@ static status_t DoSession(const String aDesc, DataIO & aIO, const String & bDesc
 
    while(true)
    {
-      const int aReadFD  = aIO.GetReadSelectSocket().GetFileDescriptor();
-      const int bReadFD  = bIO.GetReadSelectSocket().GetFileDescriptor();
-      const int aWriteFD = aIO.GetWriteSelectSocket().GetFileDescriptor();
-      const int bWriteFD = bIO.GetWriteSelectSocket().GetFileDescriptor();
+      const SocketDescriptor aReadSD  = aIO.GetReadSelectSocket().GetSocketDescriptor();
+      const SocketDescriptor bReadSD  = bIO.GetReadSelectSocket().GetSocketDescriptor();
+      const SocketDescriptor aWriteSD = aIO.GetWriteSelectSocket().GetSocketDescriptor();
+      const SocketDescriptor bWriteSD = bIO.GetWriteSelectSocket().GetSocketDescriptor();
 
-      multiplexer.RegisterSocketForReadReady(aReadFD);
-      multiplexer.RegisterSocketForReadReady(bReadFD);
-      if (outgoingAData.HasItems()) multiplexer.RegisterSocketForWriteReady(aWriteFD);
-      if (outgoingBData.HasItems()) multiplexer.RegisterSocketForWriteReady(bWriteFD);
+      multiplexer.RegisterSocketForReadReady(aReadSD);
+      multiplexer.RegisterSocketForReadReady(bReadSD);
+      if (outgoingAData.HasItems()) multiplexer.RegisterSocketForWriteReady(aWriteSD);
+      if (outgoingBData.HasItems()) multiplexer.RegisterSocketForWriteReady(bWriteSD);
 
       if (multiplexer.WaitForEvents() >= 0)
       {

--- a/test/uploadstress.cpp
+++ b/test/uploadstress.cpp
@@ -36,14 +36,14 @@ int main(int argc, char ** argv)
       gw.SetDataIO(DataIORef(new TCPSocketDataIO(s, false)));
       while(true)
       {
-         const int fd = s.GetFileDescriptor();
-         multiplexer.RegisterSocketForReadReady(fd);
-         multiplexer.RegisterSocketForWriteReady(fd);
+         const SocketDescriptor sd = s.GetSocketDescriptor();
+         multiplexer.RegisterSocketForReadReady(sd);
+         multiplexer.RegisterSocketForWriteReady(sd);
 
          if (multiplexer.WaitForEvents() < 0) printf("uploadstress: WaitForEvents() failed!\n");
 
-         const bool reading = multiplexer.IsSocketReadyForRead(fd);
-         const bool writing = multiplexer.IsSocketReadyForWrite(fd);
+         const bool reading = multiplexer.IsSocketReadyForRead(sd);
+         const bool writing = multiplexer.IsSocketReadyForWrite(sd);
 
          if (gw.HasBytesToOutput() == false)
          {

--- a/util/NetworkUtilityFunctions.h
+++ b/util/NetworkUtilityFunctions.h
@@ -778,10 +778,10 @@ typedef int muscle_socklen_t;
 typedef size_t muscle_socklen_t;
 #endif
 
-static inline long recv_ignore_eintr(    int s, void *b, unsigned long numBytes, int flags) {long ret; do {ret = recv(s, (char *)b, numBytes, flags);} while((ret<0)&&(PreviousOperationWasInterrupted())); return ret;}
-static inline long recvfrom_ignore_eintr(int s, void *b, unsigned long numBytes, int flags, struct sockaddr *a, muscle_socklen_t * alen) {long ret; do {ret = recvfrom(s, (char *)b, numBytes, flags, a,  alen);} while((ret<0)&&(PreviousOperationWasInterrupted())); return ret;}
-static inline long send_ignore_eintr(    int s, const void *b, unsigned long numBytes, int flags) {long ret; do {ret = send(s, (char *)b, numBytes, flags);} while((ret<0)&&(PreviousOperationWasInterrupted())); return ret;}
-static inline long sendto_ignore_eintr(  int s, const void *b, unsigned long numBytes, int flags, const struct sockaddr * d, int dlen) {long ret; do {ret = sendto(s, (char *)b, numBytes, flags,  d, dlen);} while((ret<0)&&(PreviousOperationWasInterrupted())); return ret;}
+static inline long recv_ignore_eintr(    SocketDescriptor s, void *b, unsigned long numBytes, int flags) {long ret; do {ret = recv(s, (char *)b, numBytes, flags);} while((ret<0)&&(PreviousOperationWasInterrupted())); return ret;}
+static inline long recvfrom_ignore_eintr(SocketDescriptor s, void *b, unsigned long numBytes, int flags, struct sockaddr *a, muscle_socklen_t * alen) {long ret; do {ret = recvfrom(s, (char *)b, numBytes, flags, a,  alen);} while((ret<0)&&(PreviousOperationWasInterrupted())); return ret;}
+static inline long send_ignore_eintr(    SocketDescriptor s, const void *b, unsigned long numBytes, int flags) {long ret; do {ret = send(s, (char *)b, numBytes, flags);} while((ret<0)&&(PreviousOperationWasInterrupted())); return ret;}
+static inline long sendto_ignore_eintr(  SocketDescriptor s, const void *b, unsigned long numBytes, int flags, const struct sockaddr * d, int dlen) {long ret; do {ret = sendto(s, (char *)b, numBytes, flags,  d, dlen);} while((ret<0)&&(PreviousOperationWasInterrupted())); return ret;}
 #ifndef WIN32
 static inline long read_ignore_eintr(    int f, void *b, unsigned long nbyte) {long ret; do {ret = read(f, (char *)b, nbyte);} while((ret<0)&&(PreviousOperationWasInterrupted())); return ret;}
 static inline long write_ignore_eintr(   int f, const void *b, unsigned long nbyte) {long ret; do {ret = write(f, (char *)b, nbyte);} while((ret<0)&&(PreviousOperationWasInterrupted())); return ret;}

--- a/util/Socket.h
+++ b/util/Socket.h
@@ -9,50 +9,79 @@
 
 namespace muscle {
 
+/** Descriptor type. */
+#ifdef WIN32
+   typedef SOCKET SocketDescriptor;
+#else
+   typedef int SocketDescriptor;
+#define INVALID_SOCKET -1
+#endif
+
+/** Format specifier for SocketDescriptor */
+#ifdef _WIN64
+#define SOCKET_FORMAT_SPEC UINT64_FORMAT_SPEC
+#elif defined(_WIN32)
+#define SOCKET_FORMAT_SPEC UINT32_FORMAT_SPEC
+#else
+#define SOCKET_FORMAT_SPEC "%i"
+#endif
+
+/** Is socket descriptor valid?
+  * @param sd The socket descriptor to be tested
+  */
+static inline bool isValidSocket(SocketDescriptor sd) {
+#ifdef WIN32
+   return sd != INVALID_SOCKET;
+#else
+   return sd >= 0;
+#endif
+}
+
 /** A simple socket-holder class to make sure that opened socket file
   * descriptors don't get accidentally leaked.  A Socket object is typically
   * handed to a ConstSocketRef, whose constructor and destructor will implement
   * the reference-counting necessary to automatically delete/recycle the Socket
-  * object (and thereby automatically close its held file descriptor) when the file 
+  * object (and thereby automatically close its held socket descriptor) when the socket
   * descriptor is no longer needed for anything.
   */
 class Socket : public RefCountable, private NotCopyable
 {
 public:
+
    /** Default constructor. */
-   Socket() : _fd(-1), _okayToClose(false) {/* empty */}
+   Socket() : _sd(INVALID_SOCKET), _okayToClose(false) {/* empty */}
 
    /** Constructor.
-     * @param fd File descriptor of a socket.  (fd) becomes property of this Socket object.
-     * @param okayToClose If true (fd) will be closed by the destructor.
-     *                    If false, we will not close (fd).  Defaults to true. 
+     * @param sd Descriptor of a socket.  (sd) becomes property of this Socket object.
+     * @param okayToClose If true (sd) will be closed by the destructor.
+     *                    If false, we will not close (sd).  Defaults to true.
      */
-   explicit Socket(int fd, bool okayToClose = true) : _fd(fd), _okayToClose(okayToClose) {/* empty */}
+   explicit Socket(SocketDescriptor sd, bool okayToClose = true) : _sd(sd), _okayToClose(okayToClose) {/* empty */}
 
-   /** Destructor.  Closes our held file descriptor, if we have one. */
+   /** Destructor.  Closes our held descriptor, if we have one. */
    virtual ~Socket();
 
-   /** Returns and releases our held file descriptor.   
+   /** Returns and releases our held descriptor.
      * When this method returns, ownership of the socket is transferred to the calling code.
      */
-   int ReleaseFileDescriptor() {int ret = _fd; _fd = -1; return ret;}
+   SocketDescriptor ReleaseSocketDescriptor() { SocketDescriptor ret = _sd; _sd = INVALID_SOCKET; return ret;}
 
-   /** Returns the held socket fd, but does not release ownership of it. */  
-   int GetFileDescriptor() const {return _fd;}
+   /** Returns the held socket descriptor, but does not release ownership of it. */
+   SocketDescriptor GetSocketDescriptor() const {return _sd;}
 
    /** Sets our file descriptor.  Will close any old one if appropriate.
-     * @param fd The new file descriptor to hold, or -1 if we shouldn't hold a file descriptor any more.
-     * @param okayToCloseFD true iff we should close (fd) when we're done with it, false if we shouldn't.
-     *                    Note that this argument affects only what we'll do with (fd), and NOT what
-     *                    we'll do with any file descriptor we may already be holding!.  This argument
-     *                    is not meaningful when (fd) is passed in as -1.
+     * @param sd The new descriptor to hold, or INVALID_SOCKET if we shouldn't hold a descriptor any more.
+     * @param okayToCloseSD true iff we should close (sd) when we're done with it, false if we shouldn't.
+     *                    Note that this argument affects only what we'll do with (sd), and NOT what
+     *                    we'll do with any descriptor we may already be holding!.  This argument
+     *                    is not meaningful when (sd) is passed in as INVALID_SOCKET.
      */
-   void SetFileDescriptor(int fd, bool okayToCloseFD = true);
+   void SetSocketDescriptor(SocketDescriptor sd, bool okayToCloseSD = true);
 
-   /** Resets this Socket object to its just-constructed state, freeing any held socket descriptor if appropriate. 
-     * This call is equivalent to calling SetFileDescriptor(-1, false).
-     */ 
-   void Clear() {SetFileDescriptor(-1, false);}
+   /** Resets this Socket object to its just-constructed state, freeing any held socket descriptor if appropriate.
+     * This call is equivalent to calling SetFileDescriptor(INVALID_SOCKET, false).
+     */
+   void Clear() {SetSocketDescriptor(INVALID_SOCKET, false);}
 
 private:
    friend class ObjectPool<Socket>;
@@ -60,7 +89,7 @@ private:
    /** Assignment operator, used only for ObjectPool recycling, private on purpose */
    Socket & operator = (const Socket & /*rhs*/) {Clear(); return *this;}
 
-   int _fd;
+   SocketDescriptor _sd;
    bool _okayToClose;
 
    DECLARE_COUNTED_OBJECT(Socket);
@@ -101,37 +130,37 @@ public:
    /** Comparison operator.  Returns true iff (this) and (rhs) both contain the same file descriptor.
      * @param rhs the ConstSocketRef to compare file descriptors with
      */
-   inline bool operator ==(const ConstSocketRef &rhs) const {return GetFileDescriptor() == rhs.GetFileDescriptor();}
+   inline bool operator ==(const ConstSocketRef &rhs) const {return GetSocketDescriptor() == rhs.GetSocketDescriptor();}
 
    /** Comparison operator.  Returns true iff (this) and (rhs) don't both contain the same file descriptor.
      * @param rhs the ConstSocketRef to compare file descriptors with
      */
-   inline bool operator !=(const ConstSocketRef &rhs) const {return GetFileDescriptor() != rhs.GetFileDescriptor();}
+   inline bool operator !=(const ConstSocketRef &rhs) const {return GetSocketDescriptor() != rhs.GetSocketDescriptor();}
 
-   /** Convenience method.  Returns the file descriptor we are holding, or -1 if we are a NULL reference. */
-   int GetFileDescriptor() const {const Socket * s = GetItemPointer(); return s?s->GetFileDescriptor():-1;}
+   /** Convenience method.  Returns the file descriptor we are holding, or INVALID_SOCKET if we are a NULL reference. */
+   SocketDescriptor GetSocketDescriptor() const {const Socket * s = GetItemPointer(); return s?s->GetSocketDescriptor():INVALID_SOCKET;}
 
    /** When we're being used as a key in a Hashtable, key on the file descriptor we hold */
-   uint32 HashCode() const {return CalculateHashCode(GetFileDescriptor());}
+   uint32 HashCode() const {return CalculateHashCode(GetSocketDescriptor());}
 };
 
 /** Returns a ConstSocketRef from our ConstSocketRef pool that references the passed in file descriptor.
   * @param fd The file descriptor that the returned ConstSocketRef should be tracking.
-  * @param okayToClose if true, (fd) will be closed when the last ConstSocketRef 
+  * @param okayToClose if true, (sd) will be closed when the last ConstSocketRef
   *                    that references it is destroyed.  If false, it won't be.
-  * @param retNULLIfInvalidSocket If left true and (fd) is negative, then a NULL ConstSocketRef
+  * @param retNULLIfInvalidSocket If left true and (sd) is invalid, then a NULL ConstSocketRef
   *                               will be returned.  If set false, then we will return a
-  *                               non-NULL ConstSocketRef object, with (fd)'s negative value in it.
+  *                               non-NULL ConstSocketRef object, with (sd)'s invalid value in it.
   * @returns a ConstSocketRef pointing to the specified socket on success, or a NULL ConstSocketRef on
-  *          failure (out of memory).  Note that in the failure case, (fd) will be closed unless
+  *          failure (out of memory).  Note that in the failure case, (sd) will be closed unless
   *          (okayToClose) was false; that way you don't have to worry about closing it yourself.
   */
-ConstSocketRef GetConstSocketRefFromPool(int fd, bool okayToClose = true, bool retNULLIfInvalidSocket = true);
+ConstSocketRef GetConstSocketRefFromPool(SocketDescriptor sd, bool okayToClose = true, bool retNULLIfInvalidSocket = true);
 
 /** Convenience method:  Returns a NULL socket reference. */
 inline const ConstSocketRef & GetNullSocket() {return GetDefaultObjectForType<ConstSocketRef>();}
 
-/** Convenience method:  Returns a reference to an invalid Socket (i.e. a Socket object with a negative file descriptor).  Note the difference between what this function returns and what GetNullSocket() returns!  If you're not sure which of these two functions to use, then GetNullSocket() is probably the one you want. */
+/** Convenience method:  Returns a reference to an invalid Socket (i.e. a Socket object with a negative socket descriptor).  Note the difference between what this function returns and what GetNullSocket() returns!  If you're not sure which of these two functions to use, then GetNullSocket() is probably the one you want. */
 const ConstSocketRef & GetInvalidSocket();
 
 } // end namespace muscle

--- a/util/SocketMultiplexer.h
+++ b/util/SocketMultiplexer.h
@@ -57,38 +57,38 @@ public:
      * socket has data ready to read.
      * @note this registration is cleared after WaitForEvents() returns, so you will generally want to re-register
      *       your socket on each iteration of your event loop.
-     * @param fd The file descriptor to watch for data-ready-to-read.
-     * @returns B_NO_ERROR on success, or an error code on failure (out of memory or bad fd value?)
+     * @param sd The socket descriptor to watch for data-ready-to-read.
+     * @returns B_NO_ERROR on success, or an error code on failure (out of memory or bad sd value?)
      */
-   inline status_t RegisterSocketForReadReady(int fd) {return GetCurrentFDState().RegisterSocket(fd, FDSTATE_SET_READ);}
+   inline status_t RegisterSocketForReadReady(SocketDescriptor sd) {return GetCurrentFDState().RegisterSocket(sd, FDSTATE_SET_READ);}
 
    /** Call this to indicate that you want the next call to WaitForEvents() to return if/when the specified
      * socket has buffer space available to write to.
      * @note this registration is cleared after WaitForEvents() returns, so you will generally want to re-register
      *       your socket on each iteration of your event loop.
-     * @param fd The file descriptor to watch for space-available-to-write.
-     * @returns B_NO_ERROR on success, or an error code on failure (out of memory or bad fd value?)
+     * @param sd The socket descriptor to watch for space-available-to-write.
+     * @returns B_NO_ERROR on success, or an error code on failure (out of memory or bad sd value?)
      */
-   inline status_t RegisterSocketForWriteReady(int fd) {return GetCurrentFDState().RegisterSocket(fd, FDSTATE_SET_WRITE);}
+   inline status_t RegisterSocketForWriteReady(SocketDescriptor sd) {return GetCurrentFDState().RegisterSocket(sd, FDSTATE_SET_WRITE);}
 
    /** Call this to indicate that you want the next call to WaitForEvents() to return if/when the specified
      * socket has buffer space available to write to.
      * @note this registration is cleared after WaitForEvents() returns, so you will generally want to re-register
      *       your socket on each iteration of your event loop.
-     * @param fd The file descriptor to watch for space-available-to-write.
-     * @returns B_NO_ERROR on success, or an error code on failure (out of memory or bad fd value?)
+     * @param sd The socket descriptor to watch for space-available-to-write.
+     * @returns B_NO_ERROR on success, or an error code on failure (out of memory or bad sd value?)
      */
-   inline status_t RegisterSocketForExceptionRaised(int fd) {return GetCurrentFDState().RegisterSocket(fd, FDSTATE_SET_EXCEPT);}
+   inline status_t RegisterSocketForExceptionRaised(SocketDescriptor sd) {return GetCurrentFDState().RegisterSocket(sd, FDSTATE_SET_EXCEPT);}
 
    /** This method is equivalent to any of the three other Register methods, except that in this method
      * you can specify the set via a FDSTATE_SET_* value.
      * @note this registration is cleared after WaitForEvents() returns, so you will generally want to re-register
      *       your socket on each iteration of your event loop.
-     * @param fd The file descriptor to watch for the event type specified by (whichSet)
+     * @param sd The socket descriptor to watch for the event type specified by (whichSet)
      * @param whichSet A FDSTATE_SET_* value indicating the type of event to watch the socket for.
      * @returns B_NO_ERROR on success, or an error code on failure (out of memory or bad fd value?)
      */
-   inline status_t RegisterSocketForEventsByTypeIndex(int fd, uint32 whichSet) {return GetCurrentFDState().RegisterSocket(fd, whichSet);}
+   inline status_t RegisterSocketForEventsByTypeIndex(SocketDescriptor sd, uint32 whichSet) {return GetCurrentFDState().RegisterSocket(sd, whichSet);}
 
    /** Blocks until at least one of the events specified in previous RegisterSocketFor*()
      * calls becomes valid, or until (timeoutAtTime), whichever comes first.
@@ -105,19 +105,19 @@ public:
 
    /** Call this after WaitForEvents() returns, to find out if the specified file descriptor has
      * data ready to read or not.
-     * @param fd The file descriptor to inquire about.  Note that (fd) must have been previously
+     * @param sd The socket descriptor to inquire about.  Note that (sd) must have been previously
      *           registered via RegisterSocketForReadyReady() for this method to work correctly.
-     * @returns true if (fd) has data ready for reading, or false if it does not.
+     * @returns true if (sd) has data ready for reading, or false if it does not.
      */
-   inline bool IsSocketReadyForRead(int fd) const {return GetAlternateFDState().IsSocketReady(fd, FDSTATE_SET_READ);}
+   inline bool IsSocketReadyForRead(SocketDescriptor sd) const {return GetAlternateFDState().IsSocketReady(sd, FDSTATE_SET_READ);}
 
    /** Call this after WaitForEvents() returns, to find out if the specified file descriptor has
      * buffer space available to write to, or not.
-     * @param fd The file descriptor to inquire about.  Note that (fd) must have been previously
+     * @param sd The socket descriptor to inquire about.  Note that (sd) must have been previously
      *           registered via RegisterSocketForWriteReady() for this method to work correctly.
-     * @returns true if (fd) has buffer space available for writing to, or false if it does not.
+     * @returns true if (sd) has buffer space available for writing to, or false if it does not.
      */
-   inline bool IsSocketReadyForWrite(int fd) const {return GetAlternateFDState().IsSocketReady(fd, FDSTATE_SET_WRITE);}
+   inline bool IsSocketReadyForWrite(SocketDescriptor sd) const {return GetAlternateFDState().IsSocketReady(sd, FDSTATE_SET_WRITE);}
 
    /** Call this after WaitForEvents() returns, to find out if the specified file descriptor has
      * an exception state raised, or not.
@@ -125,17 +125,17 @@ public:
      *           registered via RegisterSocketForExceptionRaised() for this method to work correctly.
      * @returns true if (fd) has an exception state raised, or false if it does not.
      */
-   inline bool IsSocketExceptionRaised(int fd) const {return GetAlternateFDState().IsSocketReady(fd, FDSTATE_SET_EXCEPT);}
+   inline bool IsSocketExceptionRaised(SocketDescriptor sd) const {return GetAlternateFDState().IsSocketReady(sd, FDSTATE_SET_EXCEPT);}
 
    /** Call this after WaitForEvents() returns, to find out if the specified file descriptor has
      * an event of the specified type flagged, or not.  Note that this method can be used as an
      * equivalent to any of the previous three methods.
-     * @param fd The file descriptor to inquire about.  Note that (fd) must have been previously
+     * @param sd The socket descriptor to inquire about.  Note that (sd) must have been previously
      *           registered via the appropriate RegisterSocketFor*() call for this method to work correctly.
      * @param whichSet A FDSTATE_SET_* value indicating the type of event to query the socket for.
-     * @returns true if (fd) has the specified event-type flagged, or false if it does not.
+     * @returns true if (sd) has the specified event-type flagged, or false if it does not.
      */
-   inline bool IsSocketEventOfTypeFlagged(int fd, uint32 whichSet) const {return GetAlternateFDState().IsSocketReady(fd, whichSet);}
+   inline bool IsSocketEventOfTypeFlagged(SocketDescriptor sd, uint32 whichSet) const {return GetAlternateFDState().IsSocketReady(sd, whichSet);}
 
    /** Enumeration of different types of socket-sets we support (same as those supported by select()) */
    enum {
@@ -154,56 +154,56 @@ private:
 
       void Reset();
 
-      inline status_t RegisterSocket(int fd, int whichSet)
+      inline status_t RegisterSocket(SocketDescriptor sd, int whichSet)
       {
-         if (fd < 0) return B_BAD_ARGUMENT;
+         if (!isValidSocket(sd)) return B_BAD_ARGUMENT;
 
 #if defined(MUSCLE_USE_KQUEUE) || defined(MUSCLE_USE_EPOLL)
-         uint16 * b = _bits.GetOrPut(fd);
+         uint16 * b = _bits.GetOrPut(sd);
          if (b == NULL) return B_OUT_OF_MEMORY;
          *b |= (1<<whichSet);
 #elif defined(MUSCLE_USE_POLL)
          uint32 idx;
-         if (_pollFDToArrayIndex.Get(fd, idx).IsOK()) _pollFDArray[idx].events |= GetPollBitsForFDSet(whichSet, true);
-                                                 else return PollRegisterNewSocket(fd, whichSet);
+         if (_pollFDToArrayIndex.Get(sd, idx).IsOK()) _pollFDArray[idx].events |= GetPollBitsForFDSet(whichSet, true);
+                                                 else return PollRegisterNewSocket(sd, whichSet);
 #else
-# ifndef WIN32  // Window supports file descriptors that are greater than FD_SETSIZE!  Other OS's do not
-         if (fd >= FD_SETSIZE) return B_BAD_ARGUMENT;
+# ifndef WIN32  // Window supports socket descriptors that are greater than FD_SETSIZE!  Other OS's do not
+         if (sd >= FD_SETSIZE) return B_BAD_ARGUMENT;
 # endif
-         FD_SET(fd, &_fdSets[whichSet]);
-         _maxFD[whichSet] = muscleMax(_maxFD[whichSet], fd);
+         FD_SET(sd, &_fdSets[whichSet]);
+         _maxFD[whichSet] = muscleMax(_maxFD[whichSet], sd);
 #endif
          return B_NO_ERROR;
       }
 
-      inline bool IsSocketReady(int fd, int whichSet) const 
+      inline bool IsSocketReady(SocketDescriptor sd, int whichSet) const
       {
 #if defined(MUSCLE_USE_KQUEUE) || defined(MUSCLE_USE_EPOLL)
-         return ((_bits.GetWithDefault(fd) & (1<<(whichSet+8))) != 0);
+         return ((_bits.GetWithDefault(sd) & (1<<(whichSet+8))) != 0);
 #elif defined(MUSCLE_USE_POLL)
          uint32 idx;
-         return ((_pollFDToArrayIndex.Get(fd, idx).IsOK())&&((_pollFDArray[idx].revents & GetPollBitsForFDSet(whichSet, false)) != 0));
+         return ((_pollFDToArrayIndex.Get(sd, idx).IsOK())&&((_pollFDArray[idx].revents & GetPollBitsForFDSet(whichSet, false)) != 0));
 #else
-         return (FD_ISSET(fd, const_cast<fd_set *>(&_fdSets[whichSet])) != 0);
+         return (FD_ISSET(sd, const_cast<fd_set *>(&_fdSets[whichSet])) != 0);
 #endif
       }
       int WaitForEvents(uint64 timeoutAtTime);
 
 #if defined(MUSCLE_USE_KQUEUE) || defined(MUSCLE_USE_EPOLL)
-      void NotifySocketClosed(int fd)
+      void NotifySocketClosed(SocketDescriptor sd)
       {
          MutexGuard mg(_closedSocketsMutex);
-         (void) _closedSockets.PutWithDefault(fd);
+         (void) _closedSockets.PutWithDefault(sd);
       }
 #endif
 
    private:
 #if defined(MUSCLE_USE_KQUEUE)
-      status_t AddKQueueChangeRequest(int fd, uint32 whichSet, bool add);
+      status_t AddKQueueChangeRequest(SocketDescriptor sd, uint32 whichSet, bool add);
 #endif
 #if defined(MUSCLE_USE_KQUEUE) || defined(MUSCLE_USE_EPOLL)
       status_t ComputeStateBitsChangeRequests();
-      uint32 GetMaxNumEvents() const {return _bits.GetNumItems()*2;}  // times two since each FD could have both read and write events
+      uint32 GetMaxNumEvents() const {return _bits.GetNumItems()*2;}  // times two since each socket descriptor could have both read and write events
 
       Mutex _closedSocketsMutex;  // necessary since NotifySocketClosed() might get called from any thread
       Hashtable<int, Void> _closedSockets;  // written to by NotifySocketClosed(), read-and-cleared by WaitForEvents(), protected by _closedSocketsMutex
@@ -236,14 +236,14 @@ private:
       Hashtable<int, uint32> _pollFDToArrayIndex;
       Queue<struct pollfd> _pollFDArray;
 #else
-      int _maxFD[NUM_FDSTATE_SETS];
+      SocketDescriptor _maxFD[NUM_FDSTATE_SETS];
       fd_set _fdSets[NUM_FDSTATE_SETS];
 #endif
    };
 
 #if defined(MUSCLE_USE_KQUEUE) || defined(MUSCLE_USE_EPOLL)
-   friend void NotifySocketMultiplexersThatSocketIsClosed(int);
-   void NotifySocketClosed(int fd)                    {GetCurrentFDState().NotifySocketClosed(fd);}
+   friend void NotifySocketMultiplexersThatSocketIsClosed(SocketDescriptor);
+   void NotifySocketClosed(SocketDescriptor sd)       {GetCurrentFDState().NotifySocketClosed(sd);}
    inline FDState & GetCurrentFDState()               {return _fdState;}
    inline const FDState & GetCurrentFDState() const   {return _fdState;}
    inline FDState & GetAlternateFDState()             {return _fdState;}


### PR DESCRIPTION
* WinSock API doesn't use "int" as underlying type of socket operations, so we need to use typedef to mask differences
* Define INVALID_SOCKET on all platforms except Windows to mask difference of signedness of socket descriptor type, Windows already has it defined
* Add isValidSocket() utility function to test if SocketDescriptor is valid
* Add SOCKET_FORMAT_SPEC to allow printing value of SocketDescriptor