### PR TITLE
Fix a data race in NetworkUtilityFunctions

### DIFF
--- a/util/NetworkUtilityFunctions.cpp
+++ b/util/NetworkUtilityFunctions.cpp
@@ -660,6 +660,7 @@ bool IsIPAddress(const char * s)
 #endif
 }
 
+static Mutex _cachedLocalhostAddressLock;
 static IPAddress _cachedLocalhostAddress = invalidIP;
 
 static void ExpandLocalhostAddress(IPAddress & ipAddress)
@@ -669,6 +670,7 @@ static void ExpandLocalhostAddress(IPAddress & ipAddress)
       IPAddress altRet = GetLocalHostIPOverride();  // see if the user manually specified a preferred local address
       if (altRet == invalidIP)
       {
+         MutexGuard lock(_cachedLocalhostAddressLock);
          // If not, try to grab one from the OS
          if (_cachedLocalhostAddress == invalidIP)
          {
@@ -1544,6 +1546,7 @@ status_t GetNetworkInterfaceInfos(Queue<NetworkInterfaceInfo> & results, GNIIFla
 #endif
                if (results.AddTail(NetworkInterfaceInfo(iname, "", unicastIP, netmask, broadIP, isEnabled, hasCopper, 0, hardwareType)).IsOK(ret))  // MAC address will be set later
                {
+                  MutexGuard lock(_cachedLocalhostAddressLock);
                   if (_cachedLocalhostAddress == invalidIP) _cachedLocalhostAddress = unicastIP;
                }
                else break;


### PR DESCRIPTION
When running with thread sanitiser a data race was revealed which this PR fixes.

Not sure if this is the most preferable way to solve this data race, please feel free to change it.

```
Read by thread 2:
#0	0x000000010ab6b540 in muscle::IPAddress::EqualsIgnoreInterfaceIndex(muscle::IPAddress const&) const at /submodules/zg_choir/submodules/muscle/util/IPAddress.h:44
#1	0x000000010ab6b496 in muscle::IPAddress::operator==(muscle::IPAddress const&) const at /submodules/zg_choir/submodules/muscle/util/IPAddress.h:47
#2	0x000000010b043087 in muscle::GetNetworkInterfaceInfos(muscle::Queue<muscle::NetworkInterfaceInfo>&, muscle::BitChord<8u, muscle::_bitchord_tag_class_GNIIFlags_NUM_GNII_FLAGS>) at /submodules/zg_choir/submodules/muscle/util/NetworkUtilityFunctions.cpp:1547
#3	0x000000010abe8151 in zg::GetMulticastAddresses(muscle::Hashtable<muscle::IPAddressAndPort, bool, muscle::MethodHashFunctor<muscle::IPAddressAndPort> >&, unsigned short, muscle::IPAddress const&, muscle::StringMatcher const*) at /submodules/zg_choir/src/discovery/common/DiscoveryUtilityFunctions.cpp:48
#4	0x000000010abe7f91 in zg::GetDiscoveryMulticastAddresses(muscle::Hashtable<muscle::IPAddressAndPort, bool, muscle::MethodHashFunctor<muscle::IPAddressAndPort> >&, unsigned short) at /submodules/zg_choir/src/discovery/common/DiscoveryUtilityFunctions.cpp:76
#5	0x000000010abd97be in zg::DiscoveryClientManagerSession::AddNewDiscoverySessions() at /submodules/zg_choir/src/discovery/client/SystemDiscoveryClient.cpp:225
#6	0x000000010abaac25 in zg::DiscoveryClientManagerSession::AttachedToServer() at /submodules/zg_choir/src/discovery/client/SystemDiscoveryClient.cpp:127
#7	0x000000010aeeb586 in muscle::ReflectServer::AttachNewSession(muscle::Ref<muscle::AbstractReflectSession> const&) at /submodules/zg_choir/submodules/muscle/reflector/ReflectServer.cpp:233
#8	0x000000010aee94db in muscle::ReflectServer::AddNewSession(muscle::Ref<muscle::AbstractReflectSession> const&, muscle::ConstSocketRef const&) at /submodules/zg_choir/submodules/muscle/reflector/ReflectServer.cpp:121
#9	0x000000010abd24bc in zg::DiscoveryImplementation::InternalThreadEntry() at /submodules/zg_choir/src/discovery/client/SystemDiscoveryClient.cpp:426
#10	0x000000010b016bec in muscle::Thread::InternalThreadEntryAux() at /submodules/zg_choir/submodules/muscle/system/Thread.cpp:409
#11	0x000000010b014b59 in muscle::Thread::InternalThreadEntryFunc(void*) at /submodules/zg_choir/submodules/muscle/system/Thread.h:528

Write by thread 3:
#0	0x000000010ab7db29 in muscle::IPAddress::operator=(muscle::IPAddress const&) at /submodules/zg_choir/submodules/muscle/util/IPAddress.h:39
#1	0x000000010b0430a2 in muscle::GetNetworkInterfaceInfos(muscle::Queue<muscle::NetworkInterfaceInfo>&, muscle::BitChord<8u, muscle::_bitchord_tag_class_GNIIFlags_NUM_GNII_FLAGS>) at /submodules/zg_choir/submodules/muscle/util/NetworkUtilityFunctions.cpp:1547
#2	0x000000010ab5649e in zg::GenerateLocalPeerID() [inlined] at /submodules/zg_choir/src/ZGPeerSession.cpp:42
#3	0x000000010ab563f1 in zg::ZGPeerSession::ZGPeerSession(zg::ZGPeerSettings const&) at /submodules/zg_choir/src/ZGPeerSession.cpp:82
#4	0x000000010ab50bab in zg::ZGDatabasePeerSession::ZGDatabasePeerSession(zg::ZGPeerSettings const&) at /submodules/zg_choir/src/ZGDatabasePeerSession.cpp:14
#5	0x000000010ac9955f in zg::MessageTreeDatabasePeerSession::MessageTreeDatabasePeerSession(zg::ZGPeerSettings const&) at /submodules/zg_choir/src/messagetree/server/MessageTreeDatabasePeerSession.cpp:27
#6	0x0000000109140b1e in ListenPeerSession::ListenPeerSession(muscle::String const&) at /source/server/ListenServer.cpp:63
#7	0x00000001091410eb in ListenPeerSession::ListenPeerSession(muscle::String const&) at /source/server/ListenServer.cpp:64
#8	0x0000000109143b39 in ListenServer::InternalThreadEntry() at /source/server/ListenServer.cpp:157
#9	0x000000010b016bec in muscle::Thread::InternalThreadEntryAux() at /submodules/zg_choir/submodules/muscle/system/Thread.cpp:409
#10	0x000000010b014b59 in muscle::Thread::InternalThreadEntryFunc(void*) at /submodules/zg_choir/submodules/muscle/system/Thread.h:528
```