### PR TITLE
Fix atomic increment (windows)

### DIFF
--- a/system/DetectNetworkConfigChangesSession.cpp
+++ b/system/DetectNetworkConfigChangesSession.cpp
@@ -394,7 +394,7 @@ protected:
                {
                   // Anything else is an error and we should pack it in
                   (void) CancelIPChangeNotify(&olap);
-                  _threadKeepGoingIfZero.Increment();
+                  _threadKeepGoingIfZero.AtomicIncrement();
                }
             }
             else


### PR DESCRIPTION
The changes from 9c4266ddd559dc016233c31eaa16359a5ebd33c2 did break the build on windows. This PR fixes it.