### PR TITLE
Replace setMargin with setContentsMargins

### DIFF
--- a/platform/qt/qt_muscled_browser/Browser.cpp
+++ b/platform/qt/qt_muscled_browser/Browser.cpp
@@ -65,13 +65,13 @@ BrowserWindow :: BrowserWindow()
    resize(defaultWindowWidth, defaultWindowHeight);
 
    QBoxLayout * vLayout = new QBoxLayout(QBoxLayout::TopToBottom, this);
-   vLayout->setMargin(2);
+   vLayout->setContentsMargins(2,2,2,2);
    vLayout->setSpacing(2);
    
    QWidget * topRow = new QWidget;
    {
       QBoxLayout * topRowLayout = new QBoxLayout(QBoxLayout::LeftToRight, topRow);
-      topRowLayout->setMargin(2);
+      topRowLayout->setContentsMargins(2,2,2,2);
 
       QPushButton * cloneButton = new QPushButton("Clone Window");
       connect(cloneButton, SIGNAL(clicked()), this, SLOT(CloneWindow()));


### PR DESCRIPTION
This PR makes qt_muscled_browser compatible with Qt6

setMargin is deprecated and not available anymore with Qt6, but the replacement (setContentsMargins) is available from Qt 4.7