### PR TITLE
Make JUCECallbackMechanism constructor non-virtual

### DIFF
--- a/platform/juce/JUCECallbackMechanism.h
+++ b/platform/juce/JUCECallbackMechanism.h
@@ -16,7 +16,7 @@ class JUCECallbackMechanism : public ICallbackMechanism, private juce::AsyncUpda
 {
 public:
    /** Constructor */
-   virtual JUCECallbackMechanism() {/* empty */}
+   JUCECallbackMechanism() {/* empty */}
 
 protected:
    /** May be called from any thread; triggers an asynchronous call to DispatchCallbacks() within the main thread */


### PR DESCRIPTION
Latest master produces compile error:

```
[redacted]/submodules/zg_choir/submodules/muscle/platform/juce/JUCECallbackMechanism.h:19:12: error: constructor cannot be declared 'virtual'
   virtual JUCECallbackMechanism() {/* empty */}
   ~~~~~~~ ^~~~~~~~~~~~~~~~~~~~~
1 error generated.
```

It seems to be a left-over from the destructor. See commit 2a8b60f731080f6fe35e342820acffa73ff4b56f (May 3rd).

This PR fixes the error
