### PR TITLE
fix msvc build errors due to chrono header not explicitly included

### DIFF
--- a/system/WaitCondition.h
+++ b/system/WaitCondition.h
@@ -3,6 +3,8 @@
 #ifndef MuscleWaitCondition_h
 #define MuscleWaitCondition_h
 
+#include <chrono>
+
 #include "support/NotCopyable.h"
 #include "util/TimeUtilityFunctions.h"  // for MUSCLE_TIME_NEVER
 


### PR DESCRIPTION
tested to fix building errors on MSVC 19.43.34810.0