### PR TITLE
Add server name command line option

### DIFF
--- a/platform/qt/qt_muscled_browser/Browser.cpp
+++ b/platform/qt/qt_muscled_browser/Browser.cpp
@@ -382,7 +382,7 @@ int main(int argc, char ** argv)
    // An option with a value
    const QCommandLineOption serverNameOption(QStringList() << "s" << "server-name",
            QCoreApplication::translate("main", "Specify a server name to connect to."),
-           QCoreApplication::translate("main", "localhost:1234"));
+           QCoreApplication::translate("main", "localhost:2960"));
    parser.addOption(serverNameOption);
 
    parser.process(app);

--- a/platform/qt/qt_muscled_browser/Browser.cpp
+++ b/platform/qt/qt_muscled_browser/Browser.cpp
@@ -8,6 +8,7 @@
 #include <QTreeWidgetItem>
 #include <QLayout>
 #include <QLabel>
+#include <QCommandLineParser>
 #include "Browser.h"
 #include "system/SetupSystem.h"
 #include "util/MiscUtilityFunctions.h"  // for ParseConnectArg()
@@ -54,7 +55,7 @@ private:
    String _name;
 };
 
-BrowserWindow :: BrowserWindow()
+BrowserWindow :: BrowserWindow(const QString& serverName)
    : _isConnecting(false)
    , _isConnected(false)
 {
@@ -83,7 +84,10 @@ BrowserWindow :: BrowserWindow()
 
       _serverName = new QLineEdit;
       connect(_serverName, SIGNAL(returnPressed()), this, SLOT(ConnectButtonClicked()));
-      _serverName->setText("localhost:2960");
+      if (!serverName.isEmpty())
+         _serverName->setText(serverName);
+      else
+         _serverName->setText("localhost:2960");
       topRowLayout->addWidget(_serverName, 1);
 
       _connectButton = new QPushButton("Connect to Server");
@@ -323,8 +327,7 @@ void BrowserWindow :: DisconnectedFromServer()
 
 void BrowserWindow :: CloneWindow()
 {
-   BrowserWindow * clone = new BrowserWindow();
-   clone->_serverName->setText(_serverName->text());
+   BrowserWindow * clone = new BrowserWindow(_serverName->text());
    clone->show();
 }
 
@@ -373,7 +376,20 @@ int main(int argc, char ** argv)
    CompleteSetupSystem css;
    QApplication app(argc, argv);
 
-   BrowserWindow * bw = new BrowserWindow;  // must be on the heap since we call setAttribute(Qt::WA_DeleteOnClose) in the BrowserWindow constructor
+   QCommandLineParser parser;
+   parser.addHelpOption();
+
+   // An option with a value
+   const QCommandLineOption serverNameOption(QStringList() << "s" << "server-name",
+           QCoreApplication::translate("main", "Specify a server name to connect to."),
+           QCoreApplication::translate("main", "localhost:1234"));
+   parser.addOption(serverNameOption);
+
+   parser.process(app);
+
+   const QString serverName = parser.value(serverNameOption);
+
+   BrowserWindow * bw = new BrowserWindow(serverName);  // must be on the heap since we call setAttribute(Qt::WA_DeleteOnClose) in the BrowserWindow constructor
    bw->show();
    return app.exec();
 }

--- a/platform/qt/qt_muscled_browser/Browser.cpp
+++ b/platform/qt/qt_muscled_browser/Browser.cpp
@@ -82,6 +82,7 @@ BrowserWindow :: BrowserWindow()
       topRowLayout->addWidget(_stateLabel);
 
       _serverName = new QLineEdit;
+      connect(_serverName, SIGNAL(returnPressed()), this, SLOT(ConnectButtonClicked()));
       _serverName->setText("localhost:2960");
       topRowLayout->addWidget(_serverName, 1);
 

--- a/platform/qt/qt_muscled_browser/Browser.h
+++ b/platform/qt/qt_muscled_browser/Browser.h
@@ -20,7 +20,7 @@ class BrowserWindow : public QWidget
 Q_OBJECT
 
 public:
-   BrowserWindow();
+   BrowserWindow(const QString& serverName);
 
 private slots:
    void ConnectButtonClicked();


### PR DESCRIPTION
In this PR you'll find changes for convenience around using qt_muscled_browser. The first one is a command line argument (-s --server-name) which can be used to specify which server name to connect to at startup. This helps during development of muscle based software, avoiding having to manually enter the server name each startup.

The second change is a minor change which makes the serverName edit box connect to the server when hitting enter/return. No need to click the "Connect to Server" button anymore.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Users can now specify a custom server endpoint via command-line arguments using the `--server-name` or `-s` flag; defaults to localhost:2960 if not specified

<!-- end of auto-generated comment: release notes by coderabbit.ai -->